### PR TITLE
Documentation links on the plugin dock widget

### DIFF
--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -7,3 +7,5 @@ PILOT_AREA_EXTENT = {
     "type": "Polygon",
     "coordinates": [-23.960197335, 32.069186664, -25.201606226, 30.743498637],
 }
+
+DOCUMENTATION_SITE = "https://kartoza.github.io/cplus-plugin"

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -18,6 +18,8 @@ from qgis.utils import iface
 
 from ..resources import *
 
+from ..utils import open_documentation
+
 from ..definitions.defaults import PILOT_AREA_EXTENT
 
 
@@ -43,6 +45,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
     def prepare_input(self):
         """Initializes plugin input widgets"""
         self.prepare_extent_box()
+        self.help_btn.clicked.connect(open_documentation)
 
     def prepare_extent_box(self):
         """Configure the spatial extent box with the initial settings."""

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -11,17 +11,19 @@ from uuid import UUID
 
 @dataclasses.dataclass
 class SpatialExtent:
-    """ Extent object that stores
+    """Extent object that stores
     the coordinates of the area of interest
     """
+
     bbox: typing.List[float]
 
 
 @dataclasses.dataclass
 class Scenario:
-    """ Object for the handling
+    """Object for the handling
     workflow scenario information.
     """
+
     uuid: UUID
     name: str
     description: str

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+""" QGIS CPLUS plugin models
+"""
+
+import dataclasses
+import typing
+
+from uuid import UUID
+
+
+@dataclasses.dataclass
+class SpatialExtent:
+    """ Extent object that stores
+    the coordinates of the area of interest
+    """
+    bbox: typing.List[float]
+
+
+@dataclasses.dataclass
+class Scenario:
+    """ Object for the handling
+    workflow scenario information.
+    """
+    uuid: UUID
+    name: str
+    description: str
+    extent: SpatialExtent

--- a/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
+++ b/src/cplus_plugin/ui/qgis_cplus_main_dockwidget.ui
@@ -57,9 +57,12 @@
         </rect>
        </property>
        <property name="text">
-        <string>The CPLUS Plugin allows you to analyze spatial data to predict ideal locations to implement different land use projects (implementation models) depending on your priorities and goals. For complete documentation and analysis configuration, click the Help and Options buttons.</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The CPLUS Plugin allows you to analyze spatial data to predict ideal locations to implement different land use projects (implementation models) depending on your priorities and goals. Documentation is available &lt;a href=&quot;https://kartoza.github.io/cplus-plugin&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;, for analysis configuration click the Help and Options buttons.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="openExternalLinks">
         <bool>true</bool>
        </property>
       </widget>
@@ -115,14 +118,14 @@
          </spacer>
         </item>
         <item row="2" column="0" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_10">
+         <widget class="QLineEdit" name="scenario_name">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
         <item row="4" column="0" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_9">
+         <widget class="QLineEdit" name="scenario_description">
           <property name="text">
            <string/>
           </property>
@@ -204,7 +207,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_73">
           <property name="text">
-           <string>TextLabel</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -1527,7 +1530,7 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QPushButton" name="pushButton_10">
+         <widget class="QPushButton" name="help_btn">
           <property name="maximumSize">
            <size>
             <width>80</width>
@@ -1540,30 +1543,39 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_2">
+         <widget class="QPushButton" name="options_btn">
           <property name="text">
            <string>Options</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_11">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="run_btn">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string>Run </string>
           </property>
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QDialogButtonBox" name="buttonBox">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="standardButtons">
-         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-        </property>
-       </widget>
       </item>
      </layout>
     </item>

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+    Plugin utilities
+"""
+
+from qgis.PyQt import QtCore, QtGui
+from qgis.core import Qgis, QgsMessageLog
+
+from .definitions.defaults import DOCUMENTATION_SITE
+
+
+def tr(message):
+    """Get the translation for a string using Qt translation API.
+    We implement this ourselves since we do not inherit QObject.
+
+    :param message: String for translation.
+    :type message: str, QString
+
+    :returns: Translated version of message.
+    :rtype: QString
+    """
+    # noinspection PyTypeChecker,PyArgumentList,PyCallByClass
+    return QtCore.QCoreApplication.translate("QgisCplus", message)
+
+
+def log(
+    message: str,
+    name: str = "qgis_cplus",
+    info: bool = True,
+    notify: bool = True,
+):
+    """Logs the message into QGIS logs using qgis_cplus as the default
+    log instance.
+    If notify_user is True, user will be notified about the log.
+
+    :param message: The log message
+    :type message: str
+
+    :param name: Name of te log instance, qgis_cplus is the default
+    :type message: str
+
+    :param info: Whether the message is about info or a
+    warning
+    :type info: bool
+
+    :param notify: Whether to notify user about the log
+    :type notify: bool
+    """
+    level = Qgis.Info if info else Qgis.Warning
+    QgsMessageLog.logMessage(
+        message,
+        name,
+        level=level,
+        notifyUser=notify,
+    )
+
+
+def open_documentation():
+    """Opens documentation website in the default browser"""
+    QtGui.QDesktopServices.openUrl(QtCore.QUrl(DOCUMENTATION_SITE))


### PR DESCRIPTION
Fixes https://github.com/kartoza/cplus-plugin/issues/53

These updates contain also changes for the models that will be used for plugin scenarios runs.

Current dockwidget look

![image](https://github.com/kartoza/cplus-plugin/assets/2663775/02cc42ef-b2ca-420a-922d-173eb4f74dbd)

Screenshot
![cplus_dockwidget_documentation](https://github.com/kartoza/cplus-plugin/assets/2663775/332dd8cd-78cf-456b-a274-bd48e18a07f2)
