### PR TITLE
Fix tests environment

### DIFF
--- a/test/qgis_interface.py
+++ b/test/qgis_interface.py
@@ -24,8 +24,7 @@ __copyright__ = (
 
 import logging
 from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal
-from qgis.core import QgsMapLayerRegistry
-from qgis.gui import QgsMapCanvasLayer
+from qgis.core import QgsProject, QgsMapLayer
 
 LOGGER = logging.getLogger("qgis_cplus")
 
@@ -38,7 +37,7 @@ class QgisInterface(QObject):
     so most methods are simply stubs.
     """
 
-    currentLayerChanged = pyqtSignal(QgsMapCanvasLayer)
+    currentLayerChanged = pyqtSignal(QgsMapLayer)
 
     def __init__(self, canvas):
         """Constructor
@@ -50,16 +49,16 @@ class QgisInterface(QObject):
         # are added.
         LOGGER.debug("Initialising canvas...")
         # noinspection PyArgumentList
-        QgsMapLayerRegistry.instance().layersAdded.connect(self.addLayers)
+        QgsProject.instance().layersAdded.connect(self.addLayers)
         # noinspection PyArgumentList
-        QgsMapLayerRegistry.instance().layerWasAdded.connect(self.addLayer)
+        QgsProject.instance().layerWasAdded.connect(self.addLayer)
         # noinspection PyArgumentList
-        QgsMapLayerRegistry.instance().removeAll.connect(self.removeAllLayers)
+        QgsProject.instance().removeAll.connect(self.removeAllLayers)
 
         # For processing module
         self.destCrs = None
 
-    @pyqtSlot("QStringList")
+    @pyqtSlot("QList<QgsMapLayer*>")
     def addLayers(self, layers):
         """Handle layers being added to the registry so they show up in canvas.
 
@@ -74,14 +73,14 @@ class QgisInterface(QObject):
         current_layers = self.canvas.layers()
         final_layers = []
         for layer in current_layers:
-            final_layers.append(QgsMapCanvasLayer(layer))
+            final_layers.append(layer)
         for layer in layers:
-            final_layers.append(QgsMapCanvasLayer(layer))
+            final_layers.append(layer)
 
-        self.canvas.setLayerSet(final_layers)
+        self.canvas.setLayers(final_layers)
         # LOGGER.debug('Layer Count After: %s' % len(self.canvas.layers()))
 
-    @pyqtSlot("QgsMapLayer")
+    @pyqtSlot("QgsMapLayer*")
     def addLayer(self, layer):
         """Handle a layer being added to the registry so it shows up in canvas.
 
@@ -98,12 +97,12 @@ class QgisInterface(QObject):
     @pyqtSlot()
     def removeAllLayers(self):
         """Remove layers from the canvas before they get deleted."""
-        self.canvas.setLayerSet([])
+        self.canvas.setLayers([])
 
     def newProject(self):
         """Create new project."""
         # noinspection PyArgumentList
-        QgsMapLayerRegistry.instance().removeAllMapLayers()
+        QgsProject.instance().removeAllMapLayers()
 
     # ---------------- API Mock for QgsInterface follows -------------------
 
@@ -151,7 +150,7 @@ class QgisInterface(QObject):
     def activeLayer(self):
         """Get pointer to the active layer (layer selected in the legend)."""
         # noinspection PyArgumentList
-        layers = QgsMapLayerRegistry.instance().mapLayers()
+        layers = QgsProject.instance().mapLayers()
         for item in layers:
             return layers[item]
 

--- a/test/utilities_for_testing.py
+++ b/test/utilities_for_testing.py
@@ -24,10 +24,10 @@ def get_qgis_app():
     """
 
     try:
-        from qgis.PyQt import QtGui, QtCore
+        from qgis.PyQt import QtCore, QtWidgets
         from qgis.core import QgsApplication
         from qgis.gui import QgsMapCanvas
-        from .qgis_interface import QgisInterface
+        from qgis_interface import QgisInterface
     except ImportError:
         return None, None, None, None
 
@@ -36,7 +36,7 @@ def get_qgis_app():
     if QGIS_APP is None:
         gui_flag = True  # All test will run qgis in gui mode
         # noinspection PyPep8Naming
-        QGIS_APP = QgsApplication(sys.argv, gui_flag)
+        QGIS_APP = QgsApplication([], gui_flag)
         # Make sure QGIS_PREFIX_PATH is set in your env if needed!
         QGIS_APP.initQgis()
         s = QGIS_APP.showSettings()
@@ -45,7 +45,7 @@ def get_qgis_app():
     global PARENT  # pylint: disable=W0603
     if PARENT is None:
         # noinspection PyPep8Naming
-        PARENT = QtGui.QWidget()
+        PARENT = QtWidgets.QWidget()
 
     global CANVAS  # pylint: disable=W0603
     if CANVAS is None:


### PR DESCRIPTION
Change way of getting the QGIS application, map canvas, interface and the parent widget, the current logic only works for QGIS version 2.x this PR updates the functionality to work for the 3.x versions.