### PR TITLE
Progress dialog fix for stalling QGIS in windows

### DIFF
--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -55,7 +55,6 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         self.setWindowFlags(flags)
 
         # Dialog statuses
-        self.task = None
         self.analysis_running = True
         self.lbl_status.setText(
             "{}: {}".format(
@@ -99,20 +98,12 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         # Connections
         self.btn_cancel.clicked.connect(self.cancel_clicked)
 
-    def run(self, task) -> None:
-        """Starts the task to run in the background.
-
-        :param task: QgsTask which will run the dialog
-        :type task: QgsTask
+    def run_dialog(self):
+        """Runs/opens the dialog. Sets modal to modeless.
+        This will allow the dialog to display and not interfere with other processes.
         """
-
-        self.task = task
-
-        # self.task.taskTerminated.connect(self.test)
-        # self.task.taskCompleted.connect(self.test2)
-
+        self.setModal(False)
         self.show()
-        self.exec_()
 
     def get_processing_status(self) -> bool:
         """Returns the status of the processing.
@@ -185,7 +176,6 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
             self.stop_processing()
         else:
             # If close has been clicked. In this case processing were already stopped
-            self.task.cancel()  # Removes from QgsTask
             super().close()
 
     def reject(self) -> None:

--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -35,7 +35,7 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
 
     def __init__(
         self,
-        init_message="Processing...",
+        init_message="Processing",
         scenario_name="Scenario",
         minimum=0,
         maximum=100,
@@ -56,12 +56,7 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
 
         # Dialog statuses
         self.analysis_running = True
-        self.lbl_status.setText(
-            "{}: {}".format(
-                self.scenario_name,
-                tr(init_message),
-            )
-        )
+        self.change_status_message(init_message)
 
         # Progress bar
         self.progress_bar.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
@@ -137,20 +132,24 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
 
             if value >= 100:
                 # Analysis has finished
-                self.change_status_message("Analysis has finished.")
+                self.change_status_message("Analysis has finished")
                 self.processing_finished()
 
-    def change_status_message(self, message="Processing...") -> None:
+    def change_status_message(self, message="Processing") -> None:
         """Updates the status message
 
         :param message: Message to show on the status bar
         :type message: str
         """
-        final_message = "{}: {}".format(
-            self.scenario_name,
-            tr(message),
+        # Split like this so that the message gets translated, but not the scenario name
+        msg = "{} for scenario ".format(
+            message,
         )
-        self.lbl_status.setText(final_message)
+        final_msg = "{}{}".format(
+            tr(msg),
+            self.scenario_name,
+        )
+        self.lbl_status.setText(final_msg)
 
     def view_report_pdf(self) -> None:
         """Opens a PDF version of the report"""
@@ -190,7 +189,7 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
     def stop_processing(self) -> None:
         """The user cancelled the processing."""
 
-        self.change_status_message("Processing has been cancelled by the user.")
+        self.change_status_message("Processing has been cancelled by the user")
 
         # Stops the processing task
         if self.main_widget:

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -481,11 +481,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                     100,
                     main_widget=self,
                 )
-                run_progress_dialog = QgsTask.fromFunction(
-                    "Progress dialog",
-                    self.progress_dialog.run,
-                )
-                QgsApplication.taskManager().addTask(run_progress_dialog)
+                self.progress_dialog.run_dialog()
             except Exception as err:
                 self.show_message(
                     tr(

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -475,7 +475,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             try:
                 # Creates and opens the progress dialog for the analysis
                 self.progress_dialog = ProgressDialog(
-                    "Calculating the highest position...",
+                    "Calculating the highest position",
                     scenario_name,
                     0,
                     100,

--- a/test/test_progress_dialog.py
+++ b/test/test_progress_dialog.py
@@ -31,7 +31,7 @@ class CplusPluginProgressDialogTest(unittest.TestCase):
         progress_dialog = ProgressDialog(parent=PARENT)
 
         test_message = "This is a status message"
-        test_final_message = "Scenario: This is a status message"
+        test_final_message = "This is a status message for scenario Scenario"
         progress_dialog.change_status_message(test_message)
         current_message = progress_dialog.lbl_status.text()
         self.assertEqual(test_final_message, current_message)


### PR DESCRIPTION
- The progress dialog will no longer use QgsTask when it opens (this caused issues in windows)
- Is now set to modeless mode, which allows other processing/tasks/qgis to continue in the background
- This solution works on both Linux and Windows
- Messages on the dialog will now follow with the scenario name

Status message update:
![image](https://github.com/kartoza/cplus-plugin/assets/79740955/5025aa5f-2ec0-49fd-958b-500134d66f4f)
