### PR TITLE
Inclusion of NCS Pathway Carbon Layers

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -15,7 +15,7 @@ import uuid
 from qgis.PyQt import QtCore
 from qgis.core import QgsRectangle, QgsSettings
 
-from .definitions.constants import NCS_PATHWAY_SEGMENT
+from .definitions.constants import NCS_CARBON_SEGMENT, NCS_PATHWAY_SEGMENT
 
 from .models.base import (
     ImplementationModel,
@@ -701,10 +701,20 @@ class SettingsManager(QtCore.QObject):
         if not base_dir:
             return
 
+        # Pathway location
         p = Path(ncs_pathway.path)
         abs_path = f"{base_dir}/{NCS_PATHWAY_SEGMENT}/" f"{p.name}"
         abs_path = str(os.path.normpath(abs_path))
         ncs_pathway.path = abs_path
+
+        # Carbon location
+        abs_carbon_paths = []
+        for cb_path in ncs_pathway.carbon_paths:
+            cp = Path(cb_path)
+            abs_carbon_path = f"{base_dir}/{NCS_CARBON_SEGMENT}/" f"{cp.name}"
+            abs_carbon_path = str(os.path.normpath(abs_carbon_path))
+            abs_carbon_paths.append(abs_carbon_path)
+        ncs_pathway.carbon_paths = abs_carbon_paths
 
         # Remove then re-insert
         self.remove_ncs_pathway(str(ncs_pathway.uuid))

--- a/src/cplus_plugin/definitions/constants.py
+++ b/src/cplus_plugin/definitions/constants.py
@@ -5,3 +5,4 @@ Definitions for application constants.
 
 
 NCS_PATHWAY_SEGMENT = "ncs_pathways"
+NCS_CARBON_SEGMENT = "ncs_carbon"

--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -140,6 +140,7 @@ DEFAULT_NCS_PATHWAYS = [
         "systems by strategically planting trees in croplands.",
         "path": "Final_Agroforestry_Priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": ["bou_SOC_carbonsum_norm_inverse_null_con_clip.tif"],
     },
     {
         "uuid": "bd381140-64f0-43d0-be6c-50120dd6c174",
@@ -149,6 +150,10 @@ DEFAULT_NCS_PATHWAYS = [
         "efficiency.",
         "path": "Final_Animal_Management_Priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": [
+            "bou_SOC_carbonsum_norm_null_con_clip.tif",
+            "SOC_trend_30m_4_scaled_clip_norm_inverse_null_con_clip.tif",
+        ],
     },
     {
         "uuid": "fc36dd06-aea3-4067-9626-2d73916d79b0",
@@ -159,6 +164,7 @@ DEFAULT_NCS_PATHWAYS = [
         "tree density exceeding 75% with a canopy over 6m.",
         "path": "Final_Avoided_Indigenous_Forest_priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": ["bou_SOC_carbonsum_norm_null_con_clip.tif"],
     },
     {
         "uuid": "f7084946-6617-4c5d-97e8-de21059ca0d2",
@@ -169,6 +175,7 @@ DEFAULT_NCS_PATHWAYS = [
         "density less than 10%.",
         "path": "Final_Avoided_Grassland_priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": ["bou_SOC_carbonsum_norm_null_con_clip.tif"],
     },
     {
         "uuid": "00db44cf-a2e7-428a-86bb-0afedb9719ec",
@@ -179,9 +186,21 @@ DEFAULT_NCS_PATHWAYS = [
         "regions with open woodlands (vegetation density less than "
         "35% and a tree canopy greater than 2.5m) and natural "
         "wooded lands (vegetation density greater than 35% and a "
-        "tree canopy between 2.5m and 6m). ",
+        "tree canopy between 2.5m and 6m).",
         "path": "Final_Avoided_OpenWoodland_NaturalWoodedland_priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": ["bou_SOC_carbonsum_norm_null_con_clip.tif"],
+    },
+    {
+        "uuid": "7228ecae-8759-448d-b7ea-19366f74ee02",
+        "name": "Avoided Wetland Conversion",
+        "description": "Avoids carbon emissions by preventing the conversion "
+        "of wetlands in areas with a high risk of wetland loss. Wetlands "
+        "are defined as natural or semi-natural wetlands covered in "
+        "permanent or seasonal herbaceous vegetation.",
+        "path": "Final_Avoided_Wetland_priority_norm.tif",
+        "layer_type": 0,
+        "carbon_paths": ["bou_SOC_carbonsum_norm_null_con_clip.tif"],
     },
     {
         "uuid": "5475dd4a-5efc-4fb4-ae90-68ff4102591e",
@@ -190,6 +209,10 @@ DEFAULT_NCS_PATHWAYS = [
         "emissions by increasing resilience to catastrophic fire.",
         "path": "Final_Fire_Management_Priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": [
+            "bou_SOC_carbonsum_norm_null_con_clip.tif",
+            "SOC_trend_30m_4_scaled_clip_norm_inverse_null_con_clip.tif",
+        ],
     },
     {
         "uuid": "bede344c-9317-4c3f-801c-3117cc76be2c",
@@ -202,6 +225,10 @@ DEFAULT_NCS_PATHWAYS = [
         "tree density exceeding 75% with a canopy over 6m.",
         "path": "Final_Forest_Restoration_priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": [
+            "bou_SOC_carbonsum_norm_inverse_null_con_clip.tif",
+            "SOC_trend_30m_4_scaled_clip_norm_inverse_null_con_clip.tif",
+        ],
     },
     {
         "uuid": "384863e3-08d1-453b-ac5f-94ad6a6aa1fd",
@@ -214,9 +241,28 @@ DEFAULT_NCS_PATHWAYS = [
         "(vegetation density less than 35% and a tree canopy "
         "greater than 2.5m), and natural wooded lands (vegetation "
         "density greater than 75% and a tree canopy between 2.5m "
-        "and 6m). ",
+        "and 6m).",
         "path": "Final_Sananna_Restoration_priority_norm.tif",
         "layer_type": 0,
+        "carbon_paths": [
+            "bou_SOC_carbonsum_norm_inverse_null_con_clip.tif",
+            "SOC_trend_30m_4_scaled_clip_norm_inverse_null_con_clip.tif",
+        ],
+    },
+    {
+        "uuid": "540470c7-0ed8-48af-8d91-63c15e6d69d7",
+        "name": "Restoration - Wetland",
+        "description": "Sequesters carbon through the restoration of wetland "
+        "habitat. This pathway excludes the opportunity to "
+        "convert non-native wetland regions to wetlands. Wetlands "
+        "are defined as natural or semi-natural wetlands covered "
+        "in permanent or seasonal herbaceous vegetation.",
+        "path": "Final_Wetland_Restoration_priority_norm.tif",
+        "layer_type": 0,
+        "carbon_paths": [
+            "bou_SOC_carbonsum_norm_inverse_null_con_clip.tif",
+            "SOC_trend_30m_4_scaled_clip_norm_inverse_null_con_clip.tif",
+        ],
     },
     {
         "uuid": "71de0448-46c4-4163-a124-3d88cdcbba42",

--- a/src/cplus_plugin/gui/component_item_model.py
+++ b/src/cplus_plugin/gui/component_item_model.py
@@ -266,6 +266,16 @@ class NcsPathwayItem(LayerComponentItem):
 
         return json.dumps(ncs_attrs)
 
+    def is_carbon_valid(self) -> bool:
+        """Returns the validity of the carbon layers in the
+        underlying NCSPathway model object.
+
+        :returns: True if the carbon layers are valid, else
+        False.
+        :rtype: bool
+        """
+        return self.ncs_pathway.is_carbon_valid()
+
 
 class ImplementationModelItem(LayerComponentItem):
     """Standard item for an implementation model object."""
@@ -704,8 +714,12 @@ class NcsPathwayItemModel(ComponentItemModel):
             item.setIcon(QtGui.QIcon())
         else:
             error_icon = FileUtils.get_icon("mIndicatorLayerError.svg")
-            item.setToolTip(self.tr("Invalid data source"))
             item.setIcon(error_icon)
+
+            if not ncs.is_carbon_valid():
+                item.setToolTip(self.tr("Invalid carbon layer data source"))
+            else:
+                item.setToolTip(self.tr("Invalid NCS pathway data source"))
 
     def pathways(self, valid_only: bool = False) -> typing.List[NcsPathway]:
         """Returns NCS pathway objects in the model.

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -27,7 +27,7 @@ from qgis.PyQt.QtWidgets import QToolButton
 from qgis.PyQt.QtWidgets import QMenu
 
 from .conf import Settings, settings_manager
-from .definitions.constants import NCS_PATHWAY_SEGMENT
+from .definitions.constants import NCS_CARBON_SEGMENT, NCS_PATHWAY_SEGMENT
 from .definitions.defaults import (
     ABOUT_DOCUMENTATION_SITE,
     DEFAULT_IMPLEMENTATION_MODELS,
@@ -46,6 +46,7 @@ from .models.helpers import (
 from .settings import CplusOptionsFactory
 
 from .utils import (
+    FileUtils,
     log,
     open_documentation,
 )
@@ -305,6 +306,15 @@ def initialize_default_settings():
 
     This is normally called during plugin startup.
     """
+    # Create NCS subdirectories if BASE_DIR has been defined
+    base_dir = settings_manager.get_value(Settings.BASE_DIR)
+    if base_dir:
+        # Create NCS pathways subdirectory
+        FileUtils.create_ncs_pathways_dir(base_dir)
+
+        # Create NCS carbon subdirectory
+        FileUtils.create_ncs_carbon_dir(base_dir)
+
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:
         try:
@@ -314,10 +324,23 @@ def initialize_default_settings():
                 # Update dir
                 base_dir = settings_manager.get_value(Settings.BASE_DIR, None)
                 if base_dir is not None:
+                    # Pathway location
                     file_name = ncs_dict["path"]
                     absolute_path = f"{base_dir}/{NCS_PATHWAY_SEGMENT}/{file_name}"
                     abs_path = str(os.path.normpath(absolute_path))
                     ncs_dict["path"] = abs_path
+
+                    # Carbon location
+                    carbon_file_names = ncs_dict["carbon_paths"]
+                    abs_carbon_paths = []
+                    for carbon_file_name in carbon_file_names:
+                        abs_carbon_path = (
+                            f"{base_dir}/{NCS_CARBON_SEGMENT}/{carbon_file_name}"
+                        )
+                        norm_carbon_path = str(os.path.normpath(abs_carbon_path))
+                        abs_carbon_paths.append(norm_carbon_path)
+                    ncs_dict["carbon_paths"] = abs_carbon_paths
+
                 ncs_dict["user_defined"] = False
                 settings_manager.save_ncs_pathway(ncs_dict)
             else:

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -170,6 +170,8 @@ LayerModelComponentType = typing.TypeVar(
 class NcsPathway(LayerModelComponent):
     """Contains information about an NCS pathway layer."""
 
+    carbon_paths: typing.List[str] = dataclasses.field(default_factory=list)
+
     def __eq__(self, other: "NcsPathway") -> bool:
         """Test equality of NcsPathway object with another
         NcsPathway object using the attributes.
@@ -196,6 +198,18 @@ class NcsPathway(LayerModelComponent):
             return False
 
         return True
+
+    def carbon_layers(self) -> typing.List[QgsRasterLayer]:
+        """Returns the list of carbon layers whose path is defined under
+        the `carbon_paths` attribute.
+
+        The caller should check the validity of the layers.
+
+        :returns: Carbon layers for the NCS pathway or an empty list
+        if the path is not defined.
+        :rtype: list
+        """
+        return [QgsRasterLayer(carbon_path) for carbon_path in self.carbon_paths]
 
 
 @dataclasses.dataclass

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -201,15 +201,44 @@ class NcsPathway(LayerModelComponent):
 
     def carbon_layers(self) -> typing.List[QgsRasterLayer]:
         """Returns the list of carbon layers whose path is defined under
-        the `carbon_paths` attribute.
+        the :py:attr:`~carbon_paths` attribute.
 
-        The caller should check the validity of the layers.
+        The caller should check the validity of the layers or use
+        :py:meth:`~is_carbon_valid` function.
 
         :returns: Carbon layers for the NCS pathway or an empty list
         if the path is not defined.
         :rtype: list
         """
         return [QgsRasterLayer(carbon_path) for carbon_path in self.carbon_paths]
+
+    def is_carbon_valid(self) -> bool:
+        """Checks if the carbon layers are valid.
+
+        :returns: True if all carbon layers are valid, else False if
+        even one is invalid. If there are no carbon layers defined, it will
+        always return True.
+        :rtype: bool
+        """
+        is_valid = True
+        for cl in self.carbon_layers():
+            if not cl.isValid():
+                is_valid = False
+                break
+
+        return is_valid
+
+    def is_valid(self) -> bool:
+        """Additional check to include validity of carbon layers."""
+        valid = super().is_valid()
+        if not valid:
+            return False
+
+        carbon_valid = self.is_carbon_valid()
+        if not carbon_valid:
+            return False
+
+        return True
 
 
 @dataclasses.dataclass

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -131,7 +131,12 @@ def create_ncs_pathway(source_dict) -> typing.Union[NcsPathway, None]:
     from the dictionary.
     :rtype: NcsPathway
     """
-    return create_layer_component(source_dict, NcsPathway)
+    ncs = create_layer_component(source_dict, NcsPathway)
+    carbon_paths_attr = "carbon_paths"
+    if carbon_paths_attr in source_dict:
+        ncs.carbon_paths = source_dict["carbon_paths"]
+
+    return ncs
 
 
 def create_implementation_model(source_dict) -> typing.Union[ImplementationModel, None]:
@@ -198,7 +203,10 @@ def ncs_pathway_to_dict(ncs_pathway: NcsPathway, uuid_to_str=True) -> dict:
     name-value pairs.
     :rtype: dict
     """
-    return layer_component_to_dict(ncs_pathway, uuid_to_str)
+    base_ncs_dict = layer_component_to_dict(ncs_pathway, uuid_to_str)
+    base_ncs_dict["carbon_paths"] = ncs_pathway.carbon_paths
+
+    return base_ncs_dict
 
 
 def clone_layer_component(

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -13,7 +13,7 @@ from qgis.core import Qgis, QgsApplication, QgsMessageLog
 from .definitions.defaults import (
     DOCUMENTATION_SITE,
 )
-from .definitions.constants import NCS_PATHWAY_SEGMENT
+from .definitions.constants import NCS_CARBON_SEGMENT, NCS_PATHWAY_SEGMENT
 
 
 def tr(message):
@@ -127,9 +127,21 @@ class FileUtils:
 
         ncs_pathway_dir = f"{base_dir}/{NCS_PATHWAY_SEGMENT}"
         message = tr(
-            "Missing parent directory when creating NCS pathways " "subdirectory."
+            "Missing parent directory when creating NCS pathways subdirectory."
         )
         FileUtils.create_new_dir(ncs_pathway_dir, message)
+
+    @staticmethod
+    def create_ncs_carbon_dir(base_dir: str):
+        """Creates an NCS subdirectory for carbon layers under BASE_DIR.
+        Skips creation of the subdirectory if it already exists.
+        """
+        if not Path(base_dir).is_dir():
+            return
+
+        ncs_carbon_dir = f"{base_dir}/{NCS_CARBON_SEGMENT}"
+        message = tr("Missing parent directory when creating NCS carbon subdirectory.")
+        FileUtils.create_new_dir(ncs_carbon_dir, message)
 
     @staticmethod
     def create_new_dir(directory: str, log_message: str = ""):

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -47,7 +47,7 @@ def get_ncs_pathway_with_valid_carbon() -> NcsPathway:
         TEST_RASTER_PATH,
         LayerType.RASTER,
         True,
-        carbon_paths=[TEST_RASTER_PATH]
+        carbon_paths=[TEST_RASTER_PATH],
     )
 
 
@@ -60,7 +60,7 @@ def get_ncs_pathway_with_invalid_carbon() -> NcsPathway:
         TEST_RASTER_PATH,
         LayerType.RASTER,
         True,
-        carbon_paths=["tenbytenraster"]
+        carbon_paths=["tenbytenraster"],
     )
 
 

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -25,6 +25,7 @@ def get_valid_ncs_pathway() -> NcsPathway:
         TEST_RASTER_PATH,
         LayerType.RASTER,
         True,
+        carbon_paths=[],
     )
 
 
@@ -88,4 +89,5 @@ NCS_PATHWAY_DICT = {
     "path": TEST_RASTER_PATH,
     "layer_type": 0,
     "user_defined": True,
+    "carbon_paths": [],
 }

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -38,6 +38,32 @@ def get_invalid_ncs_pathway() -> NcsPathway:
     )
 
 
+def get_ncs_pathway_with_valid_carbon() -> NcsPathway:
+    """Creates a valid NCS pathway object with a valid carbon layer."""
+    return NcsPathway(
+        UUID(VALID_NCS_UUID_STR),
+        "Valid NCS Pathway",
+        "Description for valid NCS",
+        TEST_RASTER_PATH,
+        LayerType.RASTER,
+        True,
+        carbon_paths=[TEST_RASTER_PATH]
+    )
+
+
+def get_ncs_pathway_with_invalid_carbon() -> NcsPathway:
+    """Creates an NCS pathway object with an invalid carbon layer."""
+    return NcsPathway(
+        UUID(VALID_NCS_UUID_STR),
+        "Invalid NCS Pathway",
+        "Description for invalid NCS",
+        TEST_RASTER_PATH,
+        LayerType.RASTER,
+        True,
+        carbon_paths=["tenbytenraster"]
+    )
+
+
 def get_implementation_model() -> ImplementationModel:
     """Creates a test ImplementationModel object."""
     return ImplementationModel(

--- a/test/test_data_models.py
+++ b/test/test_data_models.py
@@ -35,21 +35,21 @@ class TestNcsPathway(TestCase):
 
     def test_ncs_is_valid_with_no_carbon_layers(self):
         """Confirm NCS item is valid when no carbon layers
-         are defined.
-         """
+        are defined.
+        """
         self.assertTrue(self.ncs.is_valid())
 
     def test_ncs_with_valid_carbon_layer(self):
         """Confirm NCS item is valid when a valid carbon
-         layer is defined.
-         """
+        layer is defined.
+        """
         valid_carbon_ncs = get_ncs_pathway_with_valid_carbon()
         self.assertTrue(valid_carbon_ncs.is_carbon_valid())
 
     def test_ncs_with_invalid_carbon_layer(self):
         """Confirm NCS item is invalid when an invalid
         carbon layer.
-         """
+        """
         invalid_carbon_ncs = get_ncs_pathway_with_invalid_carbon()
         self.assertFalse(invalid_carbon_ncs.is_carbon_valid())
 

--- a/test/test_data_models.py
+++ b/test/test_data_models.py
@@ -8,6 +8,8 @@ from unittest import TestCase
 from model_data_for_testing import (
     get_implementation_model,
     get_invalid_ncs_pathway,
+    get_ncs_pathway_with_invalid_carbon,
+    get_ncs_pathway_with_valid_carbon,
     get_valid_ncs_pathway,
     VALID_NCS_UUID_STR,
 )
@@ -30,6 +32,26 @@ class TestNcsPathway(TestCase):
     def test_ncs_is_not_valid(self):
         """Confirm NCS item is not valid."""
         self.assertFalse(self.invalid_ncs.is_valid())
+
+    def test_ncs_is_valid_with_no_carbon_layers(self):
+        """Confirm NCS item is valid when no carbon layers
+         are defined.
+         """
+        self.assertTrue(self.ncs.is_valid())
+
+    def test_ncs_with_valid_carbon_layer(self):
+        """Confirm NCS item is valid when a valid carbon
+         layer is defined.
+         """
+        valid_carbon_ncs = get_ncs_pathway_with_valid_carbon()
+        self.assertTrue(valid_carbon_ncs.is_carbon_valid())
+
+    def test_ncs_with_invalid_carbon_layer(self):
+        """Confirm NCS item is invalid when an invalid
+        carbon layer.
+         """
+        invalid_carbon_ncs = get_ncs_pathway_with_invalid_carbon()
+        self.assertFalse(invalid_carbon_ncs.is_carbon_valid())
 
 
 class TestImplementationModel(TestCase):


### PR DESCRIPTION
This PR incorporates carbon layers for NCS pathways. See implementation details below:

- To access the carbon layer(s) for each NCS pathway model, use `ncs.carbon_layers()`. The caller needs to check the validity of each carbon layer.
- To check the validity of the carbon layer(s), use `ncs.is_carbon_valid()`. If there are no carbon layers defined for the NCS pathway model, this function will return True.

On startup, the plugin will automatically create a `ncs_carbon` subdirectory under BASE_DIR, copy the carbon layers to this subdirectory so that the NCS pathways can be valid in Step 2 of the scenario configuration process.