### PR TITLE
Disable 3.28 and 3.30 QGIS images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
         qgis_version_tag:
           - release-3_16
           - release-3_22
-          - release-3_28
-          - release-3_30
+          - final-3_32_2
         os: [ubuntu-22.04]
 
     steps:


### PR DESCRIPTION
Removing the QGIS docker images for version 3.28 and 3.30 when running CI tests the recent images are causing the runs to fail, this is caused by an issue reported here https://github.com/qgis/QGIS/issues/54314