### PR TITLE
New extent values formatting

### DIFF
--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -7,7 +7,7 @@ import os
 
 PILOT_AREA_EXTENT = {
     "type": "Polygon",
-    "coordinates": [-23.960197335, 32.069186664, -25.201606226, 30.743498637],
+    "coordinates": [30.743498637, 32.069186664, -25.201606226, -23.960197335],
 }
 
 DEFAULT_CRS_ID = 4326


### PR DESCRIPTION
Changes in the format of the used extent values and the creation of [QgsRectangle](https://api.qgis.org/api/classQgsRectangle.html) objects from the the store extents. The stored extent values will now be
 `[extent.xMinimum(), extent.xMaximum(), extent.yMinimum(), extent.yMaximum()]` 

The plugin SpatialExtent instance will store the values in the bbox using the same format  `[extent.xMinimum(), extent.xMaximum(), extent.yMinimum(), extent.yMaximum()]` 

The  `QgsRectangle` objects will be created from the plugin extent using 
[QgsRectangle](https://api.qgis.org/api/classQgsRectangle.html#a01295025755d7d8594d3091a8d174129) (double xMin, double yMin=0, double xMax=0, double yMax=0, bool [normalize] ) constructor will be in a following format
 `QgsRectangle(stored_extent[0], stored_extent[2], stored_extent[1], stored_extent[3])`
 