### PR TITLE
Docker images changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         qgis_version_tag:
-          - release-3_16
           - release-3_22
+          - release-3_28
+          - release-3_30
           - final-3_32_2
         os: [ubuntu-22.04]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         qgis_version_tag:
+          - release-3_16
           - release-3_22
           - release-3_28
           - release-3_30


### PR DESCRIPTION
Follow up on https://github.com/kartoza/cplus-plugin/pull/203
Returning CI runs in QGIS images 3.28 and 3.30 versions as they have now been fixed in https://github.com/qgis/QGIS/commit/26a85ec69601559813cad337627e0e4bb55e194c