### PR TITLE
Fix recursion error when building site documentation

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ mergedeep == 1.3.4
 mkdocs-git-revision-date-localized-plugin == 0.11.1
 mkdocs-material-extensions == 1.0.3
 mkdocs-material == 8.1.7
-mkdocstrings-python == 1.1.2
+mkdocstrings-python == 1.6.0
 mkdocs-video == 1.1.0
 mkdocs == 1.2.3
 packaging == 21.3


### PR DESCRIPTION
Fixes https://github.com/kartoza/cplus-plugin/actions/runs/5996179986/job/16260301741, an error that occurs when building documentation for the plugin site, using the latest `mkdocstrings_python` version for documentation builds.