### PR TITLE
Enable Management of NCS Pathways

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -18,6 +18,8 @@ from qgis.core import QgsRectangle, QgsSettings
 from .definitions.defaults import PRIORITY_LAYERS
 
 from .definitions.constants import (
+    CARBON_COEFFICIENT_ATTRIBUTE,
+    CARBON_PATHS_ATTRIBUTE,
     NCS_CARBON_SEGMENT,
     NCS_PATHWAY_SEGMENT,
     PRIORITY_LAYERS_SEGMENT,
@@ -741,7 +743,7 @@ class SettingsManager(QtCore.QObject):
             p = Path(ncs_pathway.path)
             # Only update if path does not exist otherwise
             # fallback to check under base directory.
-            if not p.exists():
+            if not p.exists() or not p.is_absolute():
                 abs_path = f"{base_dir}/{NCS_PATHWAY_SEGMENT}/" f"{p.name}"
                 abs_path = str(os.path.normpath(abs_path))
                 ncs_pathway.path = abs_path
@@ -752,7 +754,7 @@ class SettingsManager(QtCore.QObject):
                 cp = Path(cb_path)
                 # Similarly, if the given carbon path does not exist then try
                 # to use the default one in the ncs_carbon directory.
-                if not cp.exists():
+                if not cp.exists() or not cp.is_absolute():
                     abs_carbon_path = f"{base_dir}/{NCS_CARBON_SEGMENT}/" f"{cp.name}"
                     abs_carbon_path = str(os.path.normpath(abs_carbon_path))
                     abs_carbon_paths.append(abs_carbon_path)

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -18,11 +18,12 @@ from qgis.core import QgsRectangle, QgsSettings
 from .definitions.defaults import PRIORITY_LAYERS
 
 from .definitions.constants import (
-    CARBON_COEFFICIENT_ATTRIBUTE,
-    CARBON_PATHS_ATTRIBUTE,
     NCS_CARBON_SEGMENT,
     NCS_PATHWAY_SEGMENT,
+    PATH_ATTRIBUTE,
+    PATHWAYS_ATTRIBUTE,
     PRIORITY_LAYERS_SEGMENT,
+    UUID_ATTRIBUTE
 )
 
 from .models.base import (
@@ -646,7 +647,7 @@ class SettingsManager(QtCore.QObject):
 
         ncs_str = json.dumps(ncs_pathway)
 
-        ncs_uuid = ncs_pathway["uuid"]
+        ncs_uuid = ncs_pathway[UUID_ATTRIBUTE]
         ncs_root = self._get_ncs_pathway_settings_base()
 
         with qgis_settings(ncs_root) as settings:
@@ -743,7 +744,7 @@ class SettingsManager(QtCore.QObject):
             p = Path(ncs_pathway.path)
             # Only update if path does not exist otherwise
             # fallback to check under base directory.
-            if not p.exists() or not p.is_absolute():
+            if not p.exists():
                 abs_path = f"{base_dir}/{NCS_PATHWAY_SEGMENT}/" f"{p.name}"
                 abs_path = str(os.path.normpath(abs_path))
                 ncs_pathway.path = abs_path
@@ -754,7 +755,7 @@ class SettingsManager(QtCore.QObject):
                 cp = Path(cb_path)
                 # Similarly, if the given carbon path does not exist then try
                 # to use the default one in the ncs_carbon directory.
-                if not cp.exists() or not cp.is_absolute():
+                if not cp.exists():
                     abs_carbon_path = f"{base_dir}/{NCS_CARBON_SEGMENT}/" f"{cp.name}"
                     abs_carbon_path = str(os.path.normpath(abs_carbon_path))
                     abs_carbon_paths.append(abs_carbon_path)
@@ -801,8 +802,8 @@ class SettingsManager(QtCore.QObject):
             for ncs in implementation_model.pathways:
                 ncs_pathways.append(str(ncs.uuid))
             implementation_model = layer_component_to_dict(implementation_model)
-            implementation_model["priority_layers"] = priority_layers
-            implementation_model["pathways"] = ncs_pathways
+            implementation_model[PRIORITY_LAYERS_SEGMENT] = priority_layers
+            implementation_model[PATHWAYS_ATTRIBUTE] = ncs_pathways
 
         if isinstance(implementation_model, dict):
             priority_layers = []
@@ -811,11 +812,11 @@ class SettingsManager(QtCore.QObject):
                     layer = self.get_priority_layer(layer_id)
                     priority_layers.append(layer)
                 if len(priority_layers) > 0:
-                    implementation_model["priority_layers"] = priority_layers
+                    implementation_model[PRIORITY_LAYERS_SEGMENT] = priority_layers
 
         implementation_model_str = json.dumps(implementation_model)
 
-        implementation_model_uuid = implementation_model["uuid"]
+        implementation_model_uuid = implementation_model[UUID_ATTRIBUTE]
         implementation_model_root = self._get_implementation_model_settings_base()
 
         with qgis_settings(implementation_model_root) as settings:
@@ -844,8 +845,8 @@ class SettingsManager(QtCore.QObject):
             ncs_uuids = []
             if implementation_model is not None:
                 implementation_model_dict = json.loads(implementation_model)
-                if "pathways" in implementation_model_dict:
-                    ncs_uuids = implementation_model_dict["pathways"]
+                if PATHWAYS_ATTRIBUTE in implementation_model_dict:
+                    ncs_uuids = implementation_model_dict[PATHWAYS_ATTRIBUTE]
 
                 implementation_model = create_implementation_model(
                     implementation_model_dict
@@ -893,12 +894,12 @@ class SettingsManager(QtCore.QObject):
 
         # PWLs path update
         for layer in implementation_model.priority_layers:
-            if layer in PRIORITY_LAYERS and base_dir not in layer.get("path"):
+            if layer in PRIORITY_LAYERS and base_dir not in layer.get(PATH_ATTRIBUTE):
                 abs_pwl_path = (
-                    f"{base_dir}/{PRIORITY_LAYERS_SEGMENT}/" f"{layer.get('path')}"
+                    f"{base_dir}/{PRIORITY_LAYERS_SEGMENT}/" f"{layer.get(PATH_ATTRIBUTE)}"
                 )
                 abs_pwl_path = str(os.path.normpath(abs_pwl_path))
-                layer["path"] = abs_pwl_path
+                layer[PATH_ATTRIBUTE] = abs_pwl_path
 
         # Remove then re-insert
         self.remove_implementation_model(str(implementation_model.uuid))

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -23,7 +23,7 @@ from .definitions.constants import (
     PATH_ATTRIBUTE,
     PATHWAYS_ATTRIBUTE,
     PRIORITY_LAYERS_SEGMENT,
-    UUID_ATTRIBUTE
+    UUID_ATTRIBUTE,
 )
 
 from .models.base import (
@@ -690,7 +690,10 @@ class SettingsManager(QtCore.QObject):
         with qgis_settings(ncs_root) as settings:
             ncs_model = settings.value(ncs_uuid, dict())
             if len(ncs_model) > 0:
-                ncs_pathway_dict = json.loads(ncs_model)
+                try:
+                    ncs_pathway_dict = json.loads(ncs_model)
+                except json.JSONDecodeError:
+                    log("NCS pathway JSON is invalid")
 
         return ncs_pathway_dict
 
@@ -844,7 +847,12 @@ class SettingsManager(QtCore.QObject):
             implementation_model = settings.value(implementation_model_uuid, None)
             ncs_uuids = []
             if implementation_model is not None:
-                implementation_model_dict = json.loads(implementation_model)
+                implementation_model_dict = {}
+                try:
+                    implementation_model_dict = json.loads(implementation_model)
+                except json.JSONDecodeError:
+                    log("Implementation model JSON is invalid.")
+
                 if PATHWAYS_ATTRIBUTE in implementation_model_dict:
                     ncs_uuids = implementation_model_dict[PATHWAYS_ATTRIBUTE]
 
@@ -896,7 +904,8 @@ class SettingsManager(QtCore.QObject):
         for layer in implementation_model.priority_layers:
             if layer in PRIORITY_LAYERS and base_dir not in layer.get(PATH_ATTRIBUTE):
                 abs_pwl_path = (
-                    f"{base_dir}/{PRIORITY_LAYERS_SEGMENT}/" f"{layer.get(PATH_ATTRIBUTE)}"
+                    f"{base_dir}/{PRIORITY_LAYERS_SEGMENT}/"
+                    f"{layer.get(PATH_ATTRIBUTE)}"
                 )
                 abs_pwl_path = str(os.path.normpath(abs_pwl_path))
                 layer[PATH_ATTRIBUTE] = abs_pwl_path

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -662,14 +662,34 @@ class SettingsManager(QtCore.QObject):
         """
         ncs_pathway = None
 
+        ncs_dict = self.get_ncs_pathway_dict(ncs_uuid)
+        if len(ncs_dict) == 0:
+            return None
+
+        ncs_pathway = create_ncs_pathway(ncs_dict)
+
+        return ncs_pathway
+
+    def get_ncs_pathway_dict(self, ncs_uuid: str) -> dict:
+        """Gets an NCS pathway attribute values as a dictionary.
+
+        :param ncs_uuid: Unique identifier for the NCS pathway object.
+        :type ncs_uuid: str
+
+        :returns: Returns the NCS pathway attribute values matching the given
+        identifier else an empty dictionary if not found.
+        :rtype: dict
+        """
+        ncs_pathway_dict = {}
+
         ncs_root = self._get_ncs_pathway_settings_base()
 
         with qgis_settings(ncs_root) as settings:
-            ncs_model = settings.value(ncs_uuid, None)
-            if ncs_model is not None:
-                ncs_pathway = create_ncs_pathway(json.loads(ncs_model))
+            ncs_model = settings.value(ncs_uuid, dict())
+            if len(ncs_model) > 0:
+                ncs_pathway_dict = json.loads(ncs_model)
 
-        return ncs_pathway
+        return ncs_pathway_dict
 
     def get_all_ncs_pathways(self) -> typing.List[NcsPathway]:
         """Get all the NCS pathway objects stored in settings.

--- a/src/cplus_plugin/definitions/constants.py
+++ b/src/cplus_plugin/definitions/constants.py
@@ -14,3 +14,13 @@ OUTPUTS_SEGMENT = "outputs"
 IM_GROUP_LAYER_NAME = "Implementation Model Maps"
 IM_WEIGHTED_GROUP_NAME = "Weighted Implementation Model Maps"
 NCS_PATHWAYS_GROUP_LAYER_NAME = "NCS Pathways Maps"
+
+# Attribute name
+CARBON_COEFFICIENT_ATTRIBUTE = "carbon_coefficient"
+CARBON_PATHS_ATTRIBUTE = "carbon_paths"
+DESCRIPTION_ATTRIBUTE = "description"
+LAYER_TYPE_ATTRIBUTE = "layer_type"
+NAME_ATTRIBUTE = "name"
+PATH_ATTRIBUTE = "path"
+USER_DEFINED_ATTRIBUTE = "user_defined"
+UUID_ATTRIBUTE = "uuid"

--- a/src/cplus_plugin/definitions/constants.py
+++ b/src/cplus_plugin/definitions/constants.py
@@ -15,12 +15,13 @@ IM_GROUP_LAYER_NAME = "Implementation Model Maps"
 IM_WEIGHTED_GROUP_NAME = "Weighted Implementation Model Maps"
 NCS_PATHWAYS_GROUP_LAYER_NAME = "NCS Pathways Maps"
 
-# Attribute name
+# Attribute names
 CARBON_COEFFICIENT_ATTRIBUTE = "carbon_coefficient"
 CARBON_PATHS_ATTRIBUTE = "carbon_paths"
 DESCRIPTION_ATTRIBUTE = "description"
 LAYER_TYPE_ATTRIBUTE = "layer_type"
 NAME_ATTRIBUTE = "name"
 PATH_ATTRIBUTE = "path"
+PATHWAYS_ATTRIBUTE = "pathways"
 USER_DEFINED_ATTRIBUTE = "user_defined"
 UUID_ATTRIBUTE = "uuid"

--- a/src/cplus_plugin/gui/carbon_item_model.py
+++ b/src/cplus_plugin/gui/carbon_item_model.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""
+MVC model for carbon layer paths.
+"""
+import os
+import typing
+from pathlib import Path
+
+from qgis.core import QgsRasterLayer
+
+from qgis.PyQt import QtCore, QtGui
+
+from ..utils import FileUtils, tr
+
+
+class CarbonLayerItem(QtGui.QStandardItem):
+    """Represents a single carbon layer path."""
+
+    def __init__(self, layer_path: str):
+        super().__init__()
+
+        self._layer_path = layer_path
+        self._is_valid = True
+        self.update(self._layer_path)
+
+    @property
+    def is_valid(self) -> bool:
+        """Returns the validity status of the carbon layer path.
+
+        The path could be invalid if it does not exist or if the
+        corresponding map layer is invalid.
+
+        :returns: True if valid, else False.
+        :rtype: bool
+        """
+        return self._is_valid
+
+    @property
+    def layer_path(self) -> str:
+        """Returns the path to the carbon layer.
+
+        :returns: Path to the carbon layer.
+        :rtype: str
+        """
+        return self._layer_path
+
+    def update(self, layer_path: str):
+        """Update the UI properties."""
+        self._layer_path = str(os.path.normpath(layer_path))
+        p = Path(self._layer_path)
+        self.setText(p.name)
+        self.setToolTip(self._layer_path)
+
+        # Check validity
+        if p.exists():
+            layer = QgsRasterLayer(layer_path)
+            if layer.isValid():
+                self._is_valid = True
+                self.setIcon(QtGui.QIcon())
+            else:
+                self._is_valid = False
+                error_icon = FileUtils.get_icon("mIndicatorLayerError.svg")
+                self.setIcon(error_icon)
+                self.setToolTip(tr("Carbon layer is not invalid."))
+        else:
+            self._is_valid = False
+            error_icon = FileUtils.get_icon("mIndicatorLayerError.svg")
+            self.setIcon(error_icon)
+            self.setToolTip(tr("File path is invalid."))
+
+    def type(self) -> int:
+        """Returns the type of the standard item.
+
+        :returns: Type identifier of the carbob item.
+        :rtype: int
+        """
+        return QtGui.QStandardItem.UserType + 5
+
+
+class CarbonLayerModel(QtGui.QStandardItemModel):
+    """View model for carbon layers."""
+
+    def __init__(
+        self, parent=None, carbon_paths: typing.Union[typing.List[str], None] = None
+    ):
+        super().__init__(parent)
+        self.setColumnCount(1)
+
+        if carbon_paths is not None:
+            for cp in carbon_paths:
+                self.add_carbon_layer(cp)
+
+    def add_carbon_layer(self, layer_path: str) -> bool:
+        """Adds a carbon layer to the model.
+
+        :param layer_path: Carbon layer path.
+        :type layer_path: str
+
+        :returns: True if the carbon layer was successfully added,
+        else False if there is an existing item with the same path.
+        """
+        if self.contains_layer_path(layer_path):
+            return False
+
+        carbon_item = CarbonLayerItem(layer_path)
+        self.appendRow(carbon_item)
+
+        return True
+
+    def carbon_layer_index(self, layer_path: str) -> QtCore.QModelIndex:
+        """Get the model index for the given layer path.
+
+        :param layer_path: Carbon layer path.
+        :type layer_path: str
+
+        :returns: The index corresponding to the given layer path else
+        an invalid index if not found.
+        :rtype: QtCore.QModelIndex
+        """
+        norm_path = str(os.path.normpath(layer_path))
+        matching_index = None
+        for r in range(self.rowCount()):
+            index = self.index(r, 0)
+            if not index.isValid():
+                continue
+            item = self.itemFromIndex(index)
+            if item.layer_path == norm_path:
+                matching_index = index
+                break
+
+        if matching_index is None:
+            return QtCore.QModelIndex()
+
+        return matching_index
+
+    def contains_layer_path(self, layer_path: str) -> bool:
+        """Checks if the specified layer path exists in the model.
+
+        :param layer_path: Carbon layer path.
+        :type layer_path: str
+
+        :returns: True if the path exists, else False.
+        :rtype: bool
+        """
+        carbon_idx = self.carbon_layer_index(layer_path)
+        if carbon_idx.isValid():
+            return True
+
+        return False
+
+    def carbon_paths(self, valid_only: bool = False) -> list:
+        """Gets all the carbon paths in the model.
+
+        :param valid_only: Only return the carbon paths that are valid.
+        :type valid_only: bool
+
+        :returns: A collection of carbon paths in the model.
+        :rtype: list
+        """
+        carbon_paths = []
+        for r in range(self.rowCount()):
+            index = self.index(r, 0)
+            item = self.itemFromIndex(index)
+            if valid_only:
+                if item.is_valid:
+                    carbon_paths.append(item.layer_path)
+            else:
+                carbon_paths.append(item.layer_path)
+
+        return carbon_paths
+
+    def update_carbon_path(self, index: QtCore.QModelIndex, layer_path: str) -> bool:
+        """Update the carbon path at the given position specified by the index.
+
+        :param index: Location to modify the carbon path.
+        :type index: QtCore.QModelIndex
+
+        :param layer_path: Carbon layer path.
+        :type layer_path: str
+
+        :returns: True if the path was successfully updated else False
+        if there is no carbon item at the given location.
+        :rtype: bool
+        """
+        if not index.isValid():
+            return False
+
+        item = self.itemFromIndex(index)
+        if item is None:
+            return False
+
+        item.update(layer_path)
+
+        return True

--- a/src/cplus_plugin/gui/component_item_model.py
+++ b/src/cplus_plugin/gui/component_item_model.py
@@ -23,7 +23,7 @@ from ..models.base import (
 from ..models.helpers import (
     clone_implementation_model,
     clone_ncs_pathway,
-    clone_layer_component,
+    copy_layer_component_attributes,
     create_ncs_pathway,
     ncs_pathway_to_dict,
 )
@@ -332,6 +332,27 @@ class ImplementationModelItem(LayerComponentItem):
         :rtype: list
         """
         return [ncs_item.ncs_pathway for ncs_item in self.ncs_items]
+
+    def ncs_item_from_original_pathway(
+        self, ncs_pathway: NcsPathway
+    ) -> typing.Union[NcsPathwayItem, None]:
+        """Retrieves the NCS item corresponding to the original NCS
+        pathway i.e. before it is added to this implementation
+        model item.
+
+        :param ncs_pathway: Original NCS pathway data model.
+        :type ncs_pathway: NcsPathway
+
+        :returns: The matching NCS pathway item in this implementation
+        model item, else None if there is no matching item.
+        """
+        ncs_uuid = str(ncs_pathway.uuid)
+        if ncs_uuid not in self._uuid_remap:
+            return None
+
+        new_uuid = self._uuid_remap[ncs_uuid]
+
+        return self.ncs_item_by_uuid(new_uuid)
 
     @property
     def original_ncs_pathways(self) -> typing.List[NcsPathway]:
@@ -1094,6 +1115,31 @@ class IMItemModel(ComponentItemModel):
         component_items = self.model_component_items()
 
         return [ci for ci in component_items if ci.type() == IMPLEMENTATION_MODEL_TYPE]
+
+    def update_ncs_pathway_items(self, ncs_pathway: NcsPathway) -> bool:
+        """Update NCS pathway items matching the given NCS pathway model.
+
+        If the NCS pathway model is not valid then the NCS pathway items
+        in the implementation model item will not be updated.
+
+        :returns: True if matching NCS pathway items have been updated,
+        else False.
+        :rtype: bool
+        """
+        if not ncs_pathway.is_valid():
+            return False
+
+        for im_item in self.model_items():
+            ncs_item_for_original = im_item.ncs_item_from_original_pathway(ncs_pathway)
+            if ncs_item_for_original is None:
+                continue
+
+            item_pathway = ncs_item_for_original.ncs_pathway
+            # Copy attribute values excluding the UUID
+            copy_layer_component_attributes(item_pathway, ncs_pathway)
+            ncs_item_for_original.update(item_pathway)
+
+        return True
 
     def remove_implementation_model(self, uuid_str: str) -> bool:
         """Remove an implementation model item from the model.

--- a/src/cplus_plugin/gui/component_item_model.py
+++ b/src/cplus_plugin/gui/component_item_model.py
@@ -582,6 +582,8 @@ class ComponentItemModel(QtGui.QStandardItemModel):
 
         self.insertRow(idx, component_item)
 
+        self.sort(0)
+
         self._re_index_rows()
 
         return True
@@ -647,6 +649,10 @@ class ComponentItemModel(QtGui.QStandardItemModel):
             return False
 
         item.update(item.model_component)
+
+        self.sort(0)
+
+        self._re_index_rows()
 
         return True
 

--- a/src/cplus_plugin/gui/component_item_model.py
+++ b/src/cplus_plugin/gui/component_item_model.py
@@ -582,8 +582,6 @@ class ComponentItemModel(QtGui.QStandardItemModel):
 
         self.insertRow(idx, component_item)
 
-        self.sort(0)
-
         self._re_index_rows()
 
         return True
@@ -649,10 +647,6 @@ class ComponentItemModel(QtGui.QStandardItemModel):
             return False
 
         item.update(item.model_component)
-
-        self.sort(0)
-
-        self._re_index_rows()
 
         return True
 
@@ -735,7 +729,12 @@ class NcsPathwayItemModel(ComponentItemModel):
         ncs_item = NcsPathwayItem.create(ncs)
         self._update_display(ncs_item)
 
-        return self.add_component_item(ncs_item)
+        status = self.add_component_item(ncs_item)
+
+        self.sort(0)
+        self._re_index_rows()
+
+        return status
 
     def update_ncs_pathway(self, ncs: NcsPathway) -> bool:
         """Updates the NCS pathway item in the model.
@@ -755,6 +754,9 @@ class NcsPathwayItemModel(ComponentItemModel):
             return False
 
         self._update_display(item)
+
+        self.sort(0)
+        self._re_index_rows()
 
         return True
 

--- a/src/cplus_plugin/gui/implementation_model_widget.py
+++ b/src/cplus_plugin/gui/implementation_model_widget.py
@@ -55,6 +55,8 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
         self.ipm_layout.addWidget(self.implementation_model_view)
         self.implementation_model_view.title = self.tr("Implementation Models")
 
+        self.ncs_pathway_view.ncs_pathway_updated.connect(self.on_ncs_pathway_updated)
+
         self.load()
 
     def load(self):
@@ -103,6 +105,10 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
             return
 
         self.implementation_model_view.add_ncs_pathway_items(all_ncs_items)
+
+    def on_ncs_pathway_updated(self, ncs_pathway: NcsPathway):
+        """Slot raised when an NCS pathway has been updated."""
+        self.implementation_model_view.update_ncs_pathway_items(ncs_pathway)
 
     def is_valid(self) -> bool:
         """Check if the user input is valid.

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -258,6 +258,8 @@ class ModelComponentWidget(QtWidgets.QWidget, WidgetUi):
 class NcsComponentWidget(ModelComponentWidget):
     """Widget for displaying and managing NCS pathways."""
 
+    ncs_pathway_updated = QtCore.pyqtSignal(NcsPathway)
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -328,6 +330,7 @@ class NcsComponentWidget(ModelComponentWidget):
             result = self.item_model.update_ncs_pathway(ncs_pathway)
             if result:
                 self._save_item(item)
+                self.ncs_pathway_updated.emit(ncs_pathway)
             self._update_ui_on_selection_changed()
 
     def _save_item(self, item: NcsPathwayItem):
@@ -592,3 +595,16 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
         if item.type() == IMPLEMENTATION_MODEL_TYPE:
             self.btn_edit.setEnabled(True)
             self.btn_edit_description.setEnabled(True)
+
+    def update_ncs_pathway_items(self, ncs_pathway: NcsPathway) -> bool:
+        """Update NCS pathway items used for IMs that are linked to the
+        given NCS pathway.
+
+        :param ncs_pathway: NCS pathway whose attribute values will be updated
+        for the related pathways used in the IMs.
+        :type ncs_pathway: NcsPathway
+
+        :returns: True if NCS pathway items were updated, else False.
+        :rtype: bool
+        """
+        return self.item_model.update_ncs_pathway_items(ncs_pathway)

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -231,11 +231,6 @@ class NcsComponentWidget(ModelComponentWidget):
         self.lst_model_items.setDragDropMode(QtWidgets.QAbstractItemView.DragOnly)
         self.lst_model_items.setAcceptDrops(False)
 
-        # Disable add, edit, remove controls for now
-        self.btn_add.setEnabled(False)
-        self.btn_remove.setEnabled(False)
-        self.btn_edit.setEnabled(False)
-
     def add_ncs_pathway(self, ncs_pathway: NcsPathway) -> bool:
         """Adds an NCS pathway object to the view.
 

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -311,7 +311,9 @@ class NcsComponentWidget(ModelComponentWidget):
         ncs_editor = NcsPathwayEditorDialog(self)
         if ncs_editor.exec_() == QtWidgets.QDialog.Accepted:
             ncs_pathway = ncs_editor.ncs_pathway
-            self.item_model.add_ncs_pathway(ncs_pathway)
+            result = self.item_model.add_ncs_pathway(ncs_pathway)
+            if result:
+                settings_manager.save_ncs_pathway(ncs_pathway)
 
     def _on_edit_item(self):
         """Edit selected NCS pathway object."""
@@ -323,7 +325,9 @@ class NcsComponentWidget(ModelComponentWidget):
         ncs_editor = NcsPathwayEditorDialog(self, item.ncs_pathway)
         if ncs_editor.exec_() == QtWidgets.QDialog.Accepted:
             ncs_pathway = ncs_editor.ncs_pathway
-            self.item_model.update_ncs_pathway(ncs_pathway)
+            result = self.item_model.update_ncs_pathway(ncs_pathway)
+            if result:
+                self._save_item(item)
             self._update_ui_on_selection_changed()
 
     def _save_item(self, item: NcsPathwayItem):
@@ -355,6 +359,7 @@ class NcsComponentWidget(ModelComponentWidget):
             == QtWidgets.QMessageBox.Yes
         ):
             self.item_model.remove_ncs_pathway(str(ncs.uuid))
+            settings_manager.remove_ncs_pathway(str(ncs.uuid))
             self.clear_description()
 
     def load(self):

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -285,12 +285,6 @@ class NcsComponentWidget(ModelComponentWidget):
         for item in items:
             self.item_model.remove_ncs_pathway(item.uuid)
 
-    def _update_ui_on_selection_changed(self):
-        """Temporarily disable edit, remove buttons."""
-        super()._update_ui_on_selection_changed()
-        self.btn_remove.setEnabled(False)
-        self.btn_edit.setEnabled(False)
-
     def pathways(self, valid_only=False) -> typing.List[NcsPathway]:
         """Returns a collection of NcsPathway objects in the list view.
 

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -191,7 +191,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
             self._ncs_pathway = NcsPathway(
                 uuid.uuid4(),
                 self.txt_name.text(),
-                self.txt_description.text(),
+                self.txt_description.toPlainText(),
                 user_defined=True,
             )
         else:

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -4,15 +4,20 @@ Dialog for creating or editing an NCS pathway entry.
 """
 
 import os
+import typing
 import uuid
 
-from qgis.PyQt import QtCore, QtGui, QtWidgets
+from qgis.core import Qgis, QgsRasterLayer
+from qgis.gui import QgsGui, QgsMessageBar
 
+from qgis.PyQt import QtCore, QtGui, QtWidgets
 from qgis.PyQt.uic import loadUiType
 
+from .carbon_item_model import CarbonLayerItem, CarbonLayerModel
+from ..conf import Settings, settings_manager
 from ..definitions.defaults import ICON_PATH
 from ..models.base import LayerType, NcsPathway
-from ..utils import FileUtils
+from ..utils import FileUtils, tr
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/ncs_pathway_editor_dialog.ui")
@@ -26,7 +31,19 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         super().__init__(parent)
         self.setupUi(self)
 
+        QgsGui.enableAutoGeometryRestore(self)
+
+        self._message_bar = QgsMessageBar()
+        self.vl_notification.addWidget(self._message_bar)
+
+        self._carbon_model = CarbonLayerModel(self)
+        self.lst_carbon_layers.setModel(self._carbon_model)
+        self.lst_carbon_layers.selectionModel().selectionChanged.connect(
+            self._on_selection_changed
+        )
+
         self.buttonBox.accepted.connect(self._on_accepted)
+        self.btn_add_layer.clicked.connect(self._on_select_file)
 
         icon_pixmap = QtGui.QPixmap(ICON_PATH)
         self.icon_la.setPixmap(icon_pixmap)
@@ -36,23 +53,31 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         add_icon = FileUtils.get_icon("symbologyAdd.svg")
         self.btn_add_carbon.setIcon(add_icon)
-        # self.btn_add_carbon.clicked.connect(self._on_add_carbon_layer)
+        self.btn_add_carbon.clicked.connect(self._on_add_carbon_layer)
 
         remove_icon = FileUtils.get_icon("symbologyRemove.svg")
         self.btn_delete_carbon.setIcon(remove_icon)
         self.btn_delete_carbon.setEnabled(False)
-        # self.btn_delete_carbon.clicked.connect(self._on_remove_carbon_layer)
+        self.btn_delete_carbon.clicked.connect(self._on_remove_carbon_layer)
 
         edit_icon = FileUtils.get_icon("mActionToggleEditing.svg")
         self.btn_edit_carbon.setIcon(edit_icon)
         self.btn_edit_carbon.setEnabled(False)
-        # self.btn_edit_carbon.clicked.connect(self._on_edit_carbon_layer)
+        self.btn_edit_carbon.clicked.connect(self._on_edit_carbon_layer)
+
+        # Set to use default carbon coefficient defined in settings
+        carbon_coefficient = settings_manager.get_value(
+            Settings.CARBON_COEFFICIENT, 0.0, float
+        )
+        self.sb_carbon_coefficient.setValue(carbon_coefficient)
 
         self._edit_mode = False
+        self._layer = None
         self._ncs_pathway = ncs_pathway
         if self._ncs_pathway is not None:
-            self._update_controls()
             self._edit_mode = True
+            self._layer = self._ncs_pathway.to_map_layer()
+            self._update_controls()
 
     @property
     def ncs_pathway(self) -> NcsPathway:
@@ -73,6 +98,18 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         """
         return self._edit_mode
 
+    @property
+    def layer(self) -> QgsRasterLayer:
+        """Returns the raster layer specified by the user,
+        either existing layers in the map canvas or from the
+        selected file.
+
+        :returns: The raster layer specified by the user or
+        None if not set.
+        :rtype: QgsRasterLayer
+        """
+        return self._layer
+
     def _update_controls(self):
         """Update controls with data from the NcsPathway object."""
         if self._ncs_pathway is None:
@@ -80,6 +117,36 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self.txt_name.setText(self._ncs_pathway.name)
         self.txt_description.setPlainText(self._ncs_pathway.description)
+        self.sb_carbon_coefficient.setValue(self._ncs_pathway.carbon_coefficient)
+
+        layer_path = self._layer.source()
+        self._add_layer_path(layer_path)
+
+        for carbon_path in self._ncs_pathway.carbon_paths:
+            self._carbon_model.add_carbon_layer(carbon_path)
+
+    def _add_layer_path(self, layer_path: str):
+        """Select or add layer path to the map layer combobox."""
+        matching_index = -1
+        num_layers = self.cbo_layer.count()
+        for index in range(num_layers):
+            layer = self.cbo_layer.layer(index)
+            if layer is None:
+                continue
+            if os.path.normpath(layer.source()) == os.path.normpath(layer_path):
+                matching_index = index
+                break
+
+        if matching_index == -1:
+            self.cbo_layer.setAdditionalItems([layer_path])
+            # Set added path as current item
+            self.cbo_layer.setCurrentIndex(num_layers)
+        else:
+            self.cbo_layer.setCurrentIndex(matching_index)
+
+    def _show_warning_message(self, message):
+        """Shows a warning message in the message bar."""
+        self._message_bar.pushMessage(message, Qgis.MessageLevel.Warning)
 
     def validate(self) -> bool:
         """Validates if name and layer have been specified.
@@ -89,26 +156,169 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         """
         status = True
 
+        self._message_bar.clearWidgets()
+
         if not self.txt_name.text():
+            msg = tr("Name cannot be empty.")
+            self._show_warning_message(msg)
+            status = False
+
+        if not self.txt_description.toPlainText():
+            msg = tr("Description cannot be empty.")
+            self._show_warning_message(msg)
+            status = False
+
+        layer = self._get_selected_map_layer()
+        if layer is None:
+            msg = tr("Map layer not specified.")
+            self._show_warning_message(msg)
+            status = False
+
+        if self._layer and not self._layer.isValid():
+            msg = tr("Map layer is not valid.")
+            self._show_warning_message(msg)
             status = False
 
         return status
 
     def _create_update_ncs_pathway(self):
         """Create or update NcsPathway from user input."""
+        layer = self._get_selected_map_layer()
+        if layer:
+            self._layer = layer
+
         if self._ncs_pathway is None:
             self._ncs_pathway = NcsPathway(
                 uuid.uuid4(),
                 self.txt_name.text(),
                 self.txt_description.text(),
-                "",
-                LayerType.VECTOR,
-                True,
+                user_defined=True,
             )
         else:
             # Update mode
             self._ncs_pathway.name = self.txt_name.text()
             self._ncs_pathway.description = self.txt_description.toPlainText()
+
+        self._ncs_pathway.path = self._layer.source()
+        self._ncs_pathway.layer_type = LayerType.RASTER
+        self._ncs_pathway.carbon_coefficient = self.sb_carbon_coefficient.value()
+        self._ncs_pathway.carbon_paths = self._carbon_model.carbon_paths()
+
+    def _get_selected_map_layer(self) -> QgsRasterLayer:
+        """Returns the currently selected map layer or None if there is
+        no item in the combobox.
+        """
+        layer = self.cbo_layer.currentLayer()
+
+        if layer is None:
+            layer_paths = self.cbo_layer.additionalItems()
+            current_path = self.cbo_layer.currentText()
+            if current_path in layer_paths:
+                layer_name = os.path.basename(current_path)
+                layer = QgsRasterLayer(current_path, layer_name)
+
+        return layer
+
+    def selected_carbon_items(self) -> typing.List[CarbonLayerItem]:
+        """Returns the selected carbon items in the list view.
+
+        :returns: A collection of the selected carbon items.
+        :rtype: list
+        """
+        selection_model = self.lst_carbon_layers.selectionModel()
+        idxs = selection_model.selectedRows()
+
+        return [self._carbon_model.item(idx.row()) for idx in idxs]
+
+    def _on_selection_changed(
+        self, selected: QtCore.QItemSelection, deselected: QtCore.QItemSelection
+    ):
+        """Slot raised when the selection in the carbon list changes."""
+        self._update_ui_on_selection_changed()
+
+    def _update_ui_on_selection_changed(self):
+        """Update UI properties on selection changed."""
+        self.btn_edit_carbon.setEnabled(True)
+        self.btn_delete_carbon.setEnabled(True)
+
+        # Disable edit and remove buttons if more than
+        # one item has been selected.
+        selected_items = self.selected_carbon_items()
+        if len(selected_items) == 0:
+            self.btn_delete_carbon.setEnabled(False)
+            self.btn_edit_carbon.setEnabled(False)
+        elif len(selected_items) > 1:
+            self.btn_edit_carbon.setEnabled(False)
+
+    def _on_add_carbon_layer(self, activated: bool):
+        """Slot raised to add a carbon layer."""
+        self._message_bar.clearWidgets()
+
+        data_dir = settings_manager.get_value(Settings.LAST_DATA_DIR, "")
+        if not data_dir and self._layer:
+            data_path = self._layer.source()
+            if os.path.exists(data_path):
+                data_dir = os.path.dirname(data_path)
+
+        if not data_dir:
+            data_dir = "/home"
+
+        carbon_path = self._show_carbon_path_selector(data_dir)
+        if not carbon_path:
+            return
+
+        if self._carbon_model.contains_layer_path(carbon_path):
+            error_tr = tr("Selected carbon layer already exists.")
+            self._show_warning_message(f"{error_tr}")
+            return
+
+        self._carbon_model.add_carbon_layer(carbon_path)
+
+    def _on_edit_carbon_layer(self, activated: bool):
+        """Slot raised to edit a carbon layer."""
+        carbon_items = self.selected_carbon_items()
+        if len(carbon_items) == 0:
+            return
+
+        carbon_item = carbon_items[0]
+        carbon_path = self._show_carbon_path_selector(carbon_item.layer_path)
+        if not carbon_path:
+            return
+
+        if self._carbon_model.contains_layer_path(carbon_path):
+            error_tr = tr("Selected carbon layer already exists.")
+            self._show_warning_message(f"{error_tr}")
+            return
+
+        carbon_item.update(carbon_path)
+
+    def _on_remove_carbon_layer(self, activated: bool):
+        """Slot raised to remove one or more selected carbon layers."""
+        carbon_items = self.selected_carbon_items()
+        if len(carbon_items) == 0:
+            return
+
+        for ci in carbon_items:
+            index = self._carbon_model.indexFromItem(ci)
+            if not index.isValid():
+                continue
+            self._carbon_model.removeRows(index.row(), 1)
+
+    def _show_carbon_path_selector(self, layer_dir: str) -> str:
+        """Show file selector dialog for selecting a carbon layer."""
+        filter_tr = tr("All files")
+
+        layer_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            self.tr("Select Carbon Layer"),
+            layer_dir,
+            f"{filter_tr} (*.*)",
+            options=QtWidgets.QFileDialog.DontResolveSymlinks,
+        )
+        if not layer_path:
+            return ""
+
+        return layer_path
 
     def _on_accepted(self):
         """Validates user input before closing."""
@@ -117,3 +327,35 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self._create_update_ncs_pathway()
         self.accept()
+
+    def _on_select_file(self, activated: bool):
+        """Slot raised to upload a raster layer."""
+        data_dir = settings_manager.get_value(Settings.LAST_DATA_DIR, "")
+        if not data_dir and self._layer:
+            data_path = self._layer.source()
+            if os.path.exists(data_path):
+                data_dir = os.path.dirname(data_path)
+
+        if not data_dir:
+            data_dir = "/home"
+
+        filter_tr = tr("All files")
+
+        layer_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            self.tr("Select NCS Pathway Layer"),
+            data_dir,
+            f"{filter_tr} (*.*)",
+            options=QtWidgets.QFileDialog.DontResolveSymlinks,
+        )
+        if not layer_path:
+            return
+
+        existing_paths = self.cbo_layer.additionalItems()
+        if layer_path in existing_paths:
+            return
+
+        self.cbo_layer.setAdditionalItems([])
+
+        self._add_layer_path(layer_path)
+        settings_manager.set_value(Settings.LAST_DATA_DIR, os.path.dirname(layer_path))

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -174,7 +174,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
             self._show_warning_message(msg)
             status = False
 
-        if self._layer and not self._layer.isValid():
+        if layer and not layer.isValid():
             msg = tr("Map layer is not valid.")
             self._show_warning_message(msg)
             status = False

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -10,8 +10,7 @@ from qgis.PyQt import QtCore, QtGui, QtWidgets
 
 from qgis.PyQt.uic import loadUiType
 
-from qgis.core import QgsApplication
-
+from ..definitions.defaults import ICON_PATH
 from ..models.base import LayerType, NcsPathway
 from ..utils import FileUtils
 
@@ -27,20 +26,33 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         super().__init__(parent)
         self.setupUi(self)
 
-        self.rb_map_canvas.toggled.connect(self._on_select_map_canvas)
-        self.rb_upload.toggled.connect(self._on_upload_from_file)
         self.buttonBox.accepted.connect(self._on_accepted)
+
+        icon_pixmap = QtGui.QPixmap(ICON_PATH)
+        self.icon_la.setPixmap(icon_pixmap)
+
+        help_icon = FileUtils.get_icon("mActionHelpContents.svg")
+        self.btn_help.setIcon(help_icon)
+
+        add_icon = FileUtils.get_icon("symbologyAdd.svg")
+        self.btn_add_carbon.setIcon(add_icon)
+        # self.btn_add_carbon.clicked.connect(self._on_add_carbon_layer)
+
+        remove_icon = FileUtils.get_icon("symbologyRemove.svg")
+        self.btn_delete_carbon.setIcon(remove_icon)
+        self.btn_delete_carbon.setEnabled(False)
+        # self.btn_delete_carbon.clicked.connect(self._on_remove_carbon_layer)
+
+        edit_icon = FileUtils.get_icon("mActionToggleEditing.svg")
+        self.btn_edit_carbon.setIcon(edit_icon)
+        self.btn_edit_carbon.setEnabled(False)
+        # self.btn_edit_carbon.clicked.connect(self._on_edit_carbon_layer)
 
         self._edit_mode = False
         self._ncs_pathway = ncs_pathway
         if self._ncs_pathway is not None:
             self._update_controls()
             self._edit_mode = True
-
-        help_icon = FileUtils.get_icon("mActionHelpContents.svg")
-        self.btn_help.setIcon(help_icon)
-
-        self.rb_map_canvas.setChecked(True)
 
     @property
     def ncs_pathway(self) -> NcsPathway:
@@ -67,7 +79,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
             return
 
         self.txt_name.setText(self._ncs_pathway.name)
-        self.txt_description.setText(self._ncs_pathway.description)
+        self.txt_description.setPlainText(self._ncs_pathway.description)
 
     def validate(self) -> bool:
         """Validates if name and layer have been specified.
@@ -79,8 +91,6 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         if not self.txt_name.text():
             status = False
-
-        # TODO: Add layer validation
 
         return status
 
@@ -98,7 +108,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
         else:
             # Update mode
             self._ncs_pathway.name = self.txt_name.text()
-            self._ncs_pathway.description = self.txt_description.text()
+            self._ncs_pathway.description = self.txt_description.toPlainText()
 
     def _on_accepted(self):
         """Validates user input before closing."""
@@ -107,17 +117,3 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self._create_update_ncs_pathway()
         self.accept()
-
-    def _on_select_map_canvas(self, toggled):
-        """Slot raised when radio button for choosing map layer
-        from map canvas has been selected.
-        """
-        if toggled:
-            self.stackedWidget.setCurrentIndex(0)
-
-    def _on_upload_from_file(self, toggled):
-        """ "Slot raised when radio button for uploading map layer from f
-        ile has been selected.
-        """
-        if toggled:
-            self.stackedWidget.setCurrentIndex(1)

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -365,7 +365,7 @@ def initialize_model_settings():
         FileUtils.create_pwls_dir(base_dir)
 
     # Use carbon coefficient values for older-version NCS pathways
-    carbon_coefficient = settings_manager.get_value(Settings.CARBON_COEFFICIENT, 0)
+    carbon_coefficient = settings_manager.get_value(Settings.CARBON_COEFFICIENT, 0, float)
 
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:
@@ -416,7 +416,7 @@ def initialize_model_settings():
     # Add default implementation models
     for imp_model_dict in DEFAULT_IMPLEMENTATION_MODELS:
         try:
-            imp_model_uuid = imp_model_dict[USER_DEFINED_ATTRIBUTE]
+            imp_model_uuid = imp_model_dict[UUID_ATTRIBUTE]
             imp_model = settings_manager.get_implementation_model(imp_model_uuid)
             if imp_model is None:
                 settings_manager.save_implementation_model(imp_model_dict)

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -29,9 +29,14 @@ from qgis.PyQt.QtWidgets import QMenu
 
 from .conf import Settings, settings_manager
 from .definitions.constants import (
+    CARBON_COEFFICIENT_ATTRIBUTE,
+    CARBON_PATHS_ATTRIBUTE,
     NCS_CARBON_SEGMENT,
     NCS_PATHWAY_SEGMENT,
+    PATH_ATTRIBUTE,
     PRIORITY_LAYERS_SEGMENT,
+    USER_DEFINED_ATTRIBUTE,
+    UUID_ATTRIBUTE
 )
 from .definitions.defaults import (
     ABOUT_DOCUMENTATION_SITE,
@@ -365,20 +370,20 @@ def initialize_model_settings():
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:
         try:
-            ncs_uuid = ncs_dict["uuid"]
+            ncs_uuid = ncs_dict[UUID_ATTRIBUTE]
             ncs = settings_manager.get_ncs_pathway(ncs_uuid)
             if ncs is None:
                 # Update dir
                 base_dir = settings_manager.get_value(Settings.BASE_DIR, None)
                 if base_dir is not None:
                     # Pathway location
-                    file_name = ncs_dict["path"]
+                    file_name = ncs_dict[PATH_ATTRIBUTE]
                     absolute_path = f"{base_dir}/{NCS_PATHWAY_SEGMENT}/{file_name}"
                     abs_path = str(os.path.normpath(absolute_path))
-                    ncs_dict["path"] = abs_path
+                    ncs_dict[PATH_ATTRIBUTE] = abs_path
 
                     # Carbon location
-                    carbon_file_names = ncs_dict["carbon_paths"]
+                    carbon_file_names = ncs_dict[CARBON_PATHS_ATTRIBUTE]
                     abs_carbon_paths = []
                     for carbon_file_name in carbon_file_names:
                         abs_carbon_path = (
@@ -386,19 +391,19 @@ def initialize_model_settings():
                         )
                         norm_carbon_path = str(os.path.normpath(abs_carbon_path))
                         abs_carbon_paths.append(norm_carbon_path)
-                    ncs_dict["carbon_paths"] = abs_carbon_paths
+                    ncs_dict[CARBON_PATHS_ATTRIBUTE] = abs_carbon_paths
 
-                ncs_dict["user_defined"] = False
-                ncs_dict["carbon_coefficient"] = carbon_coefficient
+                ncs_dict[USER_DEFINED_ATTRIBUTE] = False
+                ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = carbon_coefficient
                 settings_manager.save_ncs_pathway(ncs_dict)
             else:
                 # Update carbon coefficient value
                 # Check if carbon coefficient had previously been defined
                 ncs_dict = settings_manager.get_ncs_pathway_dict(ncs_uuid)
-                if "carbon_coefficient" in ncs_dict:
+                if CARBON_COEFFICIENT_ATTRIBUTE in ncs_dict:
                     continue
                 else:
-                    ncs_dict["carbon_coefficient"] = carbon_coefficient
+                    ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = carbon_coefficient
                     source_ncs = create_ncs_pathway(ncs_dict)
                     if source_ncs is None:
                         continue
@@ -411,14 +416,14 @@ def initialize_model_settings():
     # Add default implementation models
     for imp_model_dict in DEFAULT_IMPLEMENTATION_MODELS:
         try:
-            imp_model_uuid = imp_model_dict["uuid"]
+            imp_model_uuid = imp_model_dict[USER_DEFINED_ATTRIBUTE]
             imp_model = settings_manager.get_implementation_model(imp_model_uuid)
             if imp_model is None:
                 settings_manager.save_implementation_model(imp_model_dict)
             else:
                 pathways = imp_model.pathways
                 # Update values
-                imp_model_dict["priority_layers"] = imp_model.priority_layers
+                imp_model_dict[PRIORITY_LAYERS_SEGMENT] = imp_model.priority_layers
                 source_im = create_implementation_model(imp_model_dict)
                 if source_im is None:
                     continue

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -359,6 +359,9 @@ def initialize_model_settings():
         # Create priority weighting layers subdirectory
         FileUtils.create_pwls_dir(base_dir)
 
+    # Check if carbon coefficient has been defined
+    carbon_coefficient = settings_manager.get_value(Settings.CARBON_COEFFICIENT, 0)
+
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:
         try:

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -36,7 +36,7 @@ from .definitions.constants import (
     PATH_ATTRIBUTE,
     PRIORITY_LAYERS_SEGMENT,
     USER_DEFINED_ATTRIBUTE,
-    UUID_ATTRIBUTE
+    UUID_ATTRIBUTE,
 )
 from .definitions.defaults import (
     ABOUT_DOCUMENTATION_SITE,

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -365,7 +365,9 @@ def initialize_model_settings():
         FileUtils.create_pwls_dir(base_dir)
 
     # Use carbon coefficient values for older-version NCS pathways
-    carbon_coefficient = settings_manager.get_value(Settings.CARBON_COEFFICIENT, 0, float)
+    carbon_coefficient = settings_manager.get_value(
+        Settings.CARBON_COEFFICIENT, 0, float
+    )
 
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -359,7 +359,7 @@ def initialize_model_settings():
         # Create priority weighting layers subdirectory
         FileUtils.create_pwls_dir(base_dir)
 
-    # Check if carbon coefficient has been defined
+    # Use carbon coefficient values for older-version NCS pathways
     carbon_coefficient = settings_manager.get_value(Settings.CARBON_COEFFICIENT, 0)
 
     # Add default pathways
@@ -389,14 +389,21 @@ def initialize_model_settings():
                     ncs_dict["carbon_paths"] = abs_carbon_paths
 
                 ncs_dict["user_defined"] = False
+                ncs_dict["carbon_coefficient"] = carbon_coefficient
                 settings_manager.save_ncs_pathway(ncs_dict)
             else:
-                # Update values
-                source_ncs = create_ncs_pathway(ncs_dict)
-                if source_ncs is None:
+                # Update carbon coefficient value
+                # Check if carbon coefficient had previously been defined
+                ncs_dict = settings_manager.get_ncs_pathway_dict(ncs_uuid)
+                if "carbon_coefficient" in ncs_dict:
                     continue
-                ncs = copy_layer_component_attributes(ncs, source_ncs)
-                settings_manager.update_ncs_pathway(ncs)
+                else:
+                    ncs_dict["carbon_coefficient"] = carbon_coefficient
+                    source_ncs = create_ncs_pathway(ncs_dict)
+                    if source_ncs is None:
+                        continue
+                    ncs = copy_layer_component_attributes(ncs, source_ncs)
+                    settings_manager.update_ncs_pathway(ncs)
         except KeyError as ke:
             log(f"Default NCS configuration load error - {str(ke)}")
             continue

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -230,7 +230,7 @@ class NcsPathway(LayerModelComponent):
 
         return True
 
-    def add_carbon_layer(self, carbon_path: str) -> bool:
+    def add_carbon_path(self, carbon_path: str) -> bool:
         """Add a carbon layer path.
 
         Checks if the path has already been defined or if it exists

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -201,6 +201,7 @@ class NcsPathway(LayerModelComponent):
     """Contains information about an NCS pathway layer."""
 
     carbon_paths: typing.List[str] = dataclasses.field(default_factory=list)
+    carbon_coefficient: float = 0.0
 
     def __eq__(self, other: "NcsPathway") -> bool:
         """Test equality of NcsPathway object with another
@@ -226,6 +227,27 @@ class NcsPathway(LayerModelComponent):
 
         if self.user_defined != other.user_defined:
             return False
+
+        return True
+
+    def add_carbon_layer(self, carbon_path: str) -> bool:
+        """Add a carbon layer path.
+
+        Checks if the path has already been defined or if it exists
+        in the file system.
+
+        :returns: True if the carbon layer path was successfully
+        added, else False if the path has already been defined
+        or does not exist in the file system.
+        :rtype: bool
+        """
+        if carbon_path in self.carbon_paths:
+            return False
+
+        if not os.path.exists(carbon_path):
+            return False
+
+        self.carbon_paths.append(carbon_path)
 
         return True
 

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -340,7 +340,7 @@ def copy_layer_component_attributes(
         )
 
     for f in fields(source):
-        # Exclude uuid and map layer
+        # Exclude uuid
         if f.name == UUID_ATTRIBUTE:
             continue
         attr_val = getattr(source, f.name)

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -141,9 +141,17 @@ def create_ncs_pathway(source_dict) -> typing.Union[NcsPathway, None]:
     :rtype: NcsPathway
     """
     ncs = create_layer_component(source_dict, NcsPathway)
+
+    # We are checking because of the various iterations of the attributes
+    # in the NcsPathway class where some of these attributes might
+    # be missing.
     carbon_paths_attr = "carbon_paths"
     if carbon_paths_attr in source_dict:
         ncs.carbon_paths = source_dict["carbon_paths"]
+
+    carbon_coefficient_attr = "carbon_coefficient"
+    if carbon_coefficient_attr in source_dict:
+        ncs.carbon_coefficient = source_dict["carbon_coefficient"]
 
     return ncs
 
@@ -219,6 +227,7 @@ def ncs_pathway_to_dict(ncs_pathway: NcsPathway, uuid_to_str=True) -> dict:
     """
     base_ncs_dict = layer_component_to_dict(ncs_pathway, uuid_to_str)
     base_ncs_dict["carbon_paths"] = ncs_pathway.carbon_paths
+    base_ncs_dict["carbon_coefficient"] = ncs_pathway.carbon_coefficient
 
     return base_ncs_dict
 

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -16,7 +16,17 @@ from .base import (
     NcsPathway,
     SpatialExtent,
 )
-from ..definitions.constants import CARBON_COEFFICIENT_ATTRIBUTE, CARBON_PATHS_ATTRIBUTE, NAME_ATTRIBUTE, DESCRIPTION_ATTRIBUTE, LAYER_TYPE_ATTRIBUTE, PATH_ATTRIBUTE, PRIORITY_LAYERS_SEGMENT, USER_DEFINED_ATTRIBUTE, UUID_ATTRIBUTE
+from ..definitions.constants import (
+    CARBON_COEFFICIENT_ATTRIBUTE,
+    CARBON_PATHS_ATTRIBUTE,
+    NAME_ATTRIBUTE,
+    DESCRIPTION_ATTRIBUTE,
+    LAYER_TYPE_ATTRIBUTE,
+    PATH_ATTRIBUTE,
+    PRIORITY_LAYERS_SEGMENT,
+    USER_DEFINED_ATTRIBUTE,
+    UUID_ATTRIBUTE,
+)
 from ..definitions.defaults import DEFAULT_CRS_ID
 
 from qgis.core import (
@@ -81,7 +91,9 @@ def create_model_component(
         return None
 
     return model_cls(
-        uuid.UUID(source_dict[UUID_ATTRIBUTE]), source_dict[NAME_ATTRIBUTE], source_dict[DESCRIPTION_ATTRIBUTE]
+        uuid.UUID(source_dict[UUID_ATTRIBUTE]),
+        source_dict[NAME_ATTRIBUTE],
+        source_dict[DESCRIPTION_ATTRIBUTE],
     )
 
 
@@ -123,7 +135,10 @@ def create_layer_component(
         kwargs[USER_DEFINED_ATTRIBUTE] = bool(source_dict[USER_DEFINED_ATTRIBUTE])
 
     return model_cls(
-        source_uuid, source_dict[NAME_ATTRIBUTE], source_dict[DESCRIPTION_ATTRIBUTE], **kwargs
+        source_uuid,
+        source_dict[NAME_ATTRIBUTE],
+        source_dict[DESCRIPTION_ATTRIBUTE],
+        **kwargs
     )
 
 

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -16,6 +16,7 @@ from .base import (
     NcsPathway,
     SpatialExtent,
 )
+from ..definitions.constants import CARBON_COEFFICIENT_ATTRIBUTE, CARBON_PATHS_ATTRIBUTE, NAME_ATTRIBUTE, DESCRIPTION_ATTRIBUTE, LAYER_TYPE_ATTRIBUTE, PATH_ATTRIBUTE, PRIORITY_LAYERS_SEGMENT, USER_DEFINED_ATTRIBUTE, UUID_ATTRIBUTE
 from ..definitions.defaults import DEFAULT_CRS_ID
 
 from qgis.core import (
@@ -52,9 +53,9 @@ def model_component_to_dict(
         model_uuid = str(model_uuid)
 
     return {
-        "uuid": model_uuid,
-        "name": model_component.name,
-        "description": model_component.description,
+        UUID_ATTRIBUTE: model_uuid,
+        NAME_ATTRIBUTE: model_component.name,
+        DESCRIPTION_ATTRIBUTE: model_component.description,
     }
 
 
@@ -80,7 +81,7 @@ def create_model_component(
         return None
 
     return model_cls(
-        uuid.UUID(source_dict["uuid"]), source_dict["name"], source_dict["description"]
+        uuid.UUID(source_dict[UUID_ATTRIBUTE]), source_dict[NAME_ATTRIBUTE], source_dict[DESCRIPTION_ATTRIBUTE]
     )
 
 
@@ -104,28 +105,25 @@ def create_layer_component(
     from the dictionary.
     :rtype: LayerModelComponent
     """
-    if "uuid" not in source_dict:
+    if UUID_ATTRIBUTE not in source_dict:
         return None
 
-    source_uuid = source_dict["uuid"]
+    source_uuid = source_dict[UUID_ATTRIBUTE]
     if isinstance(source_uuid, str):
         source_uuid = uuid.UUID(source_uuid)
 
     kwargs = {}
-    path_attr = "path"
-    if path_attr in source_dict:
-        kwargs[path_attr] = source_dict[path_attr]
+    if PATH_ATTRIBUTE in source_dict:
+        kwargs[PATH_ATTRIBUTE] = source_dict[PATH_ATTRIBUTE]
 
-    layer_type_attr = "layer_type"
-    if layer_type_attr in source_dict:
-        kwargs[layer_type_attr] = LayerType(int(source_dict["layer_type"]))
+    if LAYER_TYPE_ATTRIBUTE in source_dict:
+        kwargs[LAYER_TYPE_ATTRIBUTE] = LayerType(int(source_dict[LAYER_TYPE_ATTRIBUTE]))
 
-    user_defined_attr = "user_defined"
-    if user_defined_attr in source_dict:
-        kwargs[user_defined_attr] = bool(source_dict[user_defined_attr])
+    if USER_DEFINED_ATTRIBUTE in source_dict:
+        kwargs[USER_DEFINED_ATTRIBUTE] = bool(source_dict[USER_DEFINED_ATTRIBUTE])
 
     return model_cls(
-        source_uuid, source_dict["name"], source_dict["description"], **kwargs
+        source_uuid, source_dict[NAME_ATTRIBUTE], source_dict[DESCRIPTION_ATTRIBUTE], **kwargs
     )
 
 
@@ -145,13 +143,12 @@ def create_ncs_pathway(source_dict) -> typing.Union[NcsPathway, None]:
     # We are checking because of the various iterations of the attributes
     # in the NcsPathway class where some of these attributes might
     # be missing.
-    carbon_paths_attr = "carbon_paths"
-    if carbon_paths_attr in source_dict:
-        ncs.carbon_paths = source_dict["carbon_paths"]
+    if CARBON_PATHS_ATTRIBUTE in source_dict:
+        ncs.carbon_paths = source_dict[CARBON_PATHS_ATTRIBUTE]
 
-    carbon_coefficient_attr = "carbon_coefficient"
+    carbon_coefficient_attr = CARBON_COEFFICIENT_ATTRIBUTE
     if carbon_coefficient_attr in source_dict:
-        ncs.carbon_coefficient = source_dict["carbon_coefficient"]
+        ncs.carbon_coefficient = source_dict[CARBON_COEFFICIENT_ATTRIBUTE]
 
     return ncs
 
@@ -168,9 +165,8 @@ def create_implementation_model(source_dict) -> typing.Union[ImplementationModel
     :rtype: ImplementationModel
     """
     implementation_model = create_layer_component(source_dict, ImplementationModel)
-    priority_layers_attr = "priority_layers"
-    if priority_layers_attr in source_dict.keys():
-        implementation_model.priority_layers = source_dict["priority_layers"]
+    if PRIORITY_LAYERS_SEGMENT in source_dict.keys():
+        implementation_model.priority_layers = source_dict[PRIORITY_LAYERS_SEGMENT]
 
     return implementation_model
 
@@ -197,9 +193,9 @@ def layer_component_to_dict(
     :rtype: dict
     """
     base_attrs = model_component_to_dict(layer_component, uuid_to_str)
-    base_attrs["path"] = layer_component.path
-    base_attrs["layer_type"] = int(layer_component.layer_type)
-    base_attrs["user_defined"] = layer_component.user_defined
+    base_attrs[PATH_ATTRIBUTE] = layer_component.path
+    base_attrs[LAYER_TYPE_ATTRIBUTE] = int(layer_component.layer_type)
+    base_attrs[USER_DEFINED_ATTRIBUTE] = layer_component.user_defined
 
     return base_attrs
 
@@ -226,8 +222,8 @@ def ncs_pathway_to_dict(ncs_pathway: NcsPathway, uuid_to_str=True) -> dict:
     :rtype: dict
     """
     base_ncs_dict = layer_component_to_dict(ncs_pathway, uuid_to_str)
-    base_ncs_dict["carbon_paths"] = ncs_pathway.carbon_paths
-    base_ncs_dict["carbon_coefficient"] = ncs_pathway.carbon_coefficient
+    base_ncs_dict[CARBON_PATHS_ATTRIBUTE] = ncs_pathway.carbon_paths
+    base_ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = ncs_pathway.carbon_coefficient
 
     return base_ncs_dict
 
@@ -330,7 +326,7 @@ def copy_layer_component_attributes(
 
     for f in fields(source):
         # Exclude uuid and map layer
-        if f.name == "uuid" or f.name == "layer":
+        if f.name == UUID_ATTRIBUTE:
             continue
         attr_val = getattr(source, f.name)
         setattr(target, f.name, attr_val)

--- a/src/cplus_plugin/ui/model_component_widget.ui
+++ b/src/cplus_plugin/ui/model_component_widget.ui
@@ -105,8 +105,14 @@
    </item>
    <item row="4" column="0" colspan="4">
     <widget class="QLineEdit" name="txt_item_description">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="maxLength">
       <number>500</number>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/cplus_plugin/ui/model_component_widget.ui
+++ b/src/cplus_plugin/ui/model_component_widget.ui
@@ -6,54 +6,35 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>275</width>
-    <height>400</height>
+    <width>332</width>
+    <height>444</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>6</number>
-   </property>
-   <property name="topMargin">
-    <number>6</number>
-   </property>
-   <property name="rightMargin">
-    <number>6</number>
-   </property>
-   <property name="bottomMargin">
-    <number>6</number>
-   </property>
-   <item row="2" column="3">
-    <widget class="QToolButton" name="btn_remove">
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="lbl_title">
      <property name="text">
-      <string>...</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
-    <widget class="QToolButton" name="btn_reload">
-     <property name="text">
-      <string>...</string>
+   <item row="4" column="0">
+    <widget class="QLineEdit" name="txt_item_description">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="maxLength">
+      <number>500</number>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>173</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="5">
+   <item row="1" column="0" colspan="3">
     <widget class="QListView" name="lst_model_items">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
@@ -75,51 +56,82 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QToolButton" name="btn_add">
-     <property name="text">
-      <string>...</string>
+   <item row="2" column="0" colspan="3">
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>173</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btn_add">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btn_edit">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btn_remove">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="btn_reload">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QToolButton" name="btn_edit">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="5">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Description</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="5">
-    <widget class="QLabel" name="lbl_title">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QLineEdit" name="txt_item_description">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="maxLength">
-      <number>500</number>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="4">
+   <item row="4" column="1">
     <widget class="QToolButton" name="btn_edit_description">
      <property name="text">
       <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Description</string>
      </property>
     </widget>
    </item>

--- a/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
+++ b/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>442</width>
-    <height>562</height>
+    <width>501</width>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -123,7 +123,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>308</width>
+          <width>367</width>
           <height>20</height>
          </size>
         </property>

--- a/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
+++ b/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
@@ -94,6 +94,9 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="0" colspan="4">
+    <layout class="QVBoxLayout" name="vl_notification"/>
+   </item>
    <item row="2" column="0" colspan="4">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -101,10 +104,10 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="3">
+   <item row="7" column="0" colspan="3">
     <widget class="QgsMapLayerComboBox" name="cbo_layer"/>
    </item>
-   <item row="11" column="0" colspan="4">
+   <item row="10" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
      <property name="title">
       <string>Carbon layers</string>
@@ -182,7 +185,7 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="2" colspan="2">
+   <item row="11" column="2" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -192,14 +195,14 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="4">
+   <item row="6" column="0" colspan="4">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Map layer</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="4">
+   <item row="8" column="0" colspan="4">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Carbon co-efficient</string>
@@ -213,7 +216,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="3">
+   <item row="7" column="3">
     <widget class="QToolButton" name="btn_add_layer">
      <property name="text">
       <string>...</string>
@@ -223,14 +226,14 @@
    <item row="5" column="0" colspan="4">
     <widget class="QPlainTextEdit" name="txt_description"/>
    </item>
-   <item row="12" column="0">
+   <item row="11" column="0">
     <widget class="QPushButton" name="btn_help">
      <property name="text">
       <string>Help</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="1">
+   <item row="11" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -243,7 +246,7 @@
      </property>
     </spacer>
    </item>
-   <item row="10" column="0" colspan="4">
+   <item row="9" column="0" colspan="4">
     <widget class="QDoubleSpinBox" name="sb_carbon_coefficient">
      <property name="maximum">
       <double>1.000000000000000</double>
@@ -252,16 +255,6 @@
       <double>0.050000000000000</double>
      </property>
     </widget>
-   </item>
-   <item row="6" column="0" colspan="4">
-    <widget class="QLabel" name="txt_max_description">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="4">
-    <layout class="QVBoxLayout" name="vl_notification"/>
    </item>
   </layout>
  </widget>
@@ -278,6 +271,19 @@
    <header>qgsmaplayercombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>txt_name</tabstop>
+  <tabstop>txt_description</tabstop>
+  <tabstop>cbo_layer</tabstop>
+  <tabstop>btn_add_layer</tabstop>
+  <tabstop>sb_carbon_coefficient</tabstop>
+  <tabstop>btn_add_carbon</tabstop>
+  <tabstop>btn_edit_carbon</tabstop>
+  <tabstop>btn_delete_carbon</tabstop>
+  <tabstop>btn_help</tabstop>
+  <tabstop>lst_carbon_layers</tabstop>
+  <tabstop>mGroupBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
+++ b/src/cplus_plugin/ui/ncs_pathway_editor_dialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>451</width>
-    <height>326</height>
+    <width>442</width>
+    <height>562</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>NCS Pathway Editor</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0" colspan="4">
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
@@ -64,9 +64,6 @@
         <property name="text">
          <string/>
         </property>
-        <property name="pixmap">
-         <pixmap>../icons/cplus_logo.svg</pixmap>
-        </property>
         <property name="scaledContents">
          <bool>true</bool>
         </property>
@@ -81,7 +78,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify your own Natural Climate Solution Pathway. Click Help for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create or update a Natural Climate Solution (NCS) Pathway. Click Help for more information.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="scaledContents">
          <bool>false</bool>
@@ -97,111 +94,143 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="4">
+   <item row="2" column="0" colspan="4">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Name</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="4">
+   <item row="8" column="0" colspan="3">
+    <widget class="QgsMapLayerComboBox" name="cbo_layer"/>
+   </item>
+   <item row="11" column="0" colspan="4">
+    <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Carbon layers</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <property name="saveCheckedState">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>308</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="1">
+       <widget class="QToolButton" name="btn_add_carbon">
+        <property name="toolTip">
+         <string>Add carbon layer</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QToolButton" name="btn_edit_carbon">
+        <property name="toolTip">
+         <string>Edit carbon layer</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QToolButton" name="btn_delete_carbon">
+        <property name="toolTip">
+         <string>Remove carbon layer</string>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="4">
+       <widget class="QListView" name="lst_carbon_layers">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
     <widget class="QLineEdit" name="txt_name">
      <property name="maxLength">
       <number>200</number>
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="4">
+   <item row="12" column="2" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="4">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Map layer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="4">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Carbon co-efficient</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Description</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QLineEdit" name="txt_description">
-     <property name="maxLength">
-      <number>200</number>
+   <item row="8" column="3">
+    <widget class="QToolButton" name="btn_add_layer">
+     <property name="text">
+      <string>...</string>
      </property>
     </widget>
    </item>
    <item row="5" column="0" colspan="4">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>NCS pathway layer</string>
-     </property>
-    </widget>
+    <widget class="QPlainTextEdit" name="txt_description"/>
    </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QRadioButton" name="rb_map_canvas">
-     <property name="text">
-      <string>Select from map canvas</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2" colspan="2">
-    <widget class="QRadioButton" name="rb_upload">
-     <property name="text">
-      <string>Upload from file</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="4">
-    <widget class="QStackedWidget" name="stackedWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <widget class="QWidget" name="pg_map_canvas">
-      <layout class="QGridLayout" name="gridLayout_2">
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>6</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QgsMapLayerComboBox" name="mMapLayerComboBox"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="pg_upload">
-      <layout class="QGridLayout" name="gridLayout_3">
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>6</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QgsFileWidget" name="mQgsFileWidget"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="8" column="0">
+   <item row="12" column="0">
     <widget class="QPushButton" name="btn_help">
      <property name="text">
       <string>Help</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1" colspan="2">
+   <item row="12" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -214,23 +243,34 @@
      </property>
     </spacer>
    </item>
-   <item row="8" column="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="10" column="0" colspan="4">
+    <widget class="QDoubleSpinBox" name="sb_carbon_coefficient">
+     <property name="maximum">
+      <double>1.000000000000000</double>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="singleStep">
+      <double>0.050000000000000</double>
      </property>
     </widget>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QLabel" name="txt_max_description">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="4">
+    <layout class="QVBoxLayout" name="vl_notification"/>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFileWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -197,10 +197,13 @@
              <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
             </property>
             <property name="decimals">
-             <number>1</number>
+             <number>2</number>
             </property>
             <property name="maximum">
              <double>1.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.050000000000000</double>
             </property>
             <property name="value">
              <double>0.000000000000000</double>

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -128,5 +128,5 @@ NCS_PATHWAY_DICT = {
     "layer_type": 0,
     "user_defined": True,
     "carbon_paths": [],
-    "carbon_coefficient": 0.00,
+    "carbon_coefficient": 0.0,
 }

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -7,6 +7,17 @@ from uuid import UUID
 
 from qgis.core import QgsRasterLayer
 
+from cplus_plugin.definitions.constants import (
+    CARBON_COEFFICIENT_ATTRIBUTE,
+    CARBON_PATHS_ATTRIBUTE,
+    NAME_ATTRIBUTE,
+    DESCRIPTION_ATTRIBUTE,
+    LAYER_TYPE_ATTRIBUTE,
+    PATH_ATTRIBUTE,
+    PRIORITY_LAYERS_SEGMENT,
+    USER_DEFINED_ATTRIBUTE,
+    UUID_ATTRIBUTE,
+)
 from cplus_plugin.definitions.defaults import PILOT_AREA_EXTENT
 from cplus_plugin.models.base import (
     ImplementationModel,
@@ -121,12 +132,12 @@ def get_test_scenario_result() -> ScenarioResult:
 
 
 NCS_PATHWAY_DICT = {
-    "uuid": UUID(VALID_NCS_UUID_STR),
-    "name": "Valid NCS Pathway",
-    "description": "Description for valid NCS",
-    "path": TEST_RASTER_PATH,
-    "layer_type": 0,
-    "user_defined": True,
-    "carbon_paths": [],
-    "carbon_coefficient": 0.0,
+    UUID_ATTRIBUTE: UUID(VALID_NCS_UUID_STR),
+    NAME_ATTRIBUTE: "Valid NCS Pathway",
+    DESCRIPTION_ATTRIBUTE: "Description for valid NCS",
+    PATH_ATTRIBUTE: TEST_RASTER_PATH,
+    LAYER_TYPE_ATTRIBUTE: 0,
+    USER_DEFINED_ATTRIBUTE: True,
+    CARBON_PATHS_ATTRIBUTE: [],
+    CARBON_COEFFICIENT_ATTRIBUTE: 0.0,
 }

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -35,7 +35,7 @@ def get_valid_ncs_pathway() -> NcsPathway:
         LayerType.RASTER,
         True,
         carbon_paths=[],
-        carbon_coefficient=0.0
+        carbon_coefficient=0.0,
     )
 
 
@@ -128,5 +128,5 @@ NCS_PATHWAY_DICT = {
     "layer_type": 0,
     "user_defined": True,
     "carbon_paths": [],
-    "carbon_coefficient": 0.00
+    "carbon_coefficient": 0.00,
 }

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -35,6 +35,7 @@ def get_valid_ncs_pathway() -> NcsPathway:
         LayerType.RASTER,
         True,
         carbon_paths=[],
+        carbon_coefficient=0.0
     )
 
 
@@ -127,4 +128,5 @@ NCS_PATHWAY_DICT = {
     "layer_type": 0,
     "user_defined": True,
     "carbon_paths": [],
+    "carbon_coefficient": 0.00
 }


### PR DESCRIPTION
Enable adding, editing or removing NCS pathways.

The behavior of editing NCS pathways has changed and it will only be applied under the following conditions:

- The NCS pathway is a default one i.e. `ncs.user_defined = True`. These are the ones defined under `definitions/defaults.py`
- The main layer path and carbon paths could not be found hence, the module will try to default to the paths defined under `ncs_pathways` and `ncs_carbon` respectively

Incorporates features outlined in issue #106.