### PR TITLE
Updated the progress dialog

### DIFF
--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -10,14 +10,8 @@ from qgis.PyQt import (
 from qgis.PyQt.QtWidgets import QMenu, QAction, QStyle, QProgressBar
 from qgis.PyQt.QtGui import QIcon
 
-from qgis.core import (
-    QgsApplication,
-    QgsTask,
-)
-
 from ..utils import open_documentation, tr, log
 from ..definitions.defaults import (
-    ICON_PATH,
     ICON_PDF,
     ICON_LAYOUT,
     ICON_REPORT,
@@ -49,9 +43,6 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         self.scenario_id = ""
         self.main_widget = main_widget
         self.report_manager = report_manager
-
-        # Dialog window options
-        self.setWindowIcon(QIcon(ICON_PATH))
 
         # Dialog window flags
         flags = QtCore.Qt.WindowMinimizeButtonHint | QtCore.Qt.WindowCloseButtonHint
@@ -141,11 +132,6 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
             except RuntimeError:
                 log(tr("Error setting value to a progress bar"), notify=False)
 
-            if value >= 100:
-                # Analysis has finished
-                self.change_status_message(self.analysis_finished_message)
-                self.processing_finished()
-
     def change_status_message(self, message="Processing", entity="scenario") -> None:
         """Updates the status message
 
@@ -166,9 +152,12 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
 
     def set_report_complete(self):
         """Enable layout designer and PDF report buttons."""
+        self.btn_view_report.setEnabled(True)
         self.designer_action.setEnabled(True)
         self.pdf_action.setEnabled(True)
         self.report_running = False
+
+        self.processing_finished()
 
     def view_report_pdf(self) -> None:
         """Opens a PDF version of the report"""
@@ -259,9 +248,9 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         """Post-steps when processing succeeded."""
 
         self.analysis_running = False
+        self.change_status_message(self.analysis_finished_message)
 
         # Change cancel button to the close button status
         self.btn_cancel.setText(tr("Close"))
         icon = self.style().standardIcon(QStyle.SP_DialogCloseButton)
         self.btn_cancel.setIcon(icon)
-        self.btn_view_report.setEnabled(True)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -777,7 +777,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 "native:highestpositioninrasterstack"
             )
 
-            #self.processing_cancelled = False
+            # self.processing_cancelled = False
             self.task = QgsProcessingAlgRunnerTask(
                 alg,
                 alg_params,
@@ -1237,14 +1237,10 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 else:
                     # If the user cancelled the processing
                     self.show_message(
-                        tr(
-                            f"Processing has been cancelled by the user."
-                        ),
+                        tr(f"Processing has been cancelled by the user."),
                         level=Qgis.Critical,
                     )
-                    log(
-                        f"Processing has been cancelled by the user."
-                    )
+                    log(f"Processing has been cancelled by the user.")
 
                 main_task.cancel()
                 return False
@@ -1540,7 +1536,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 self.reporting_feedback.cancel()
         except Exception as e:
             log(f"Problem cancelling report generating task, {e}")
-
 
     def scenario_results(self, success, output):
         """Called when the task ends. Sets the progress bar to 100 if it finished.

--- a/test/test_progress_dialog.py
+++ b/test/test_progress_dialog.py
@@ -52,10 +52,6 @@ class CplusPluginProgressDialogTest(unittest.TestCase):
         current_value = progress_dialog.get_progress_bar().value()
         self.assertEqual(test_value, current_value)
 
-        # Checks if processing were stopped at 100% status
-        processing_status = progress_dialog.get_processing_status()
-        self.assertEqual(processing_status, False)
-
     def test_view_report(self) -> None:
         """Tests if the report is correctly opened in as a PDF"""
 


### PR DESCRIPTION
- Updates to the progress dialog to take into account changes to how the analysis is done, mostly because processing is now several tasks
- Fixed the Report button - it will now correctly be enabled only when report generating is done
- Cancel will only swap over to the Close text once report generation is done
- Cancel will now correctly stop and prevent any processing to continue
- Report generating can also now be cancelled
- Updated a testing function to take into account the changes

![image](https://github.com/kartoza/cplus-plugin/assets/79740955/4ca9e4ea-55f8-4276-9401-f898aaeed0e4)
