### PR TITLE
Report Enhancements

### DIFF
--- a/src/cplus_plugin/app_data/reports/main.qpt
+++ b/src/cplus_plugin/app_data/reports/main.qpt
@@ -1,146 +1,146 @@
-<Layout name="CPLUS Report" worldFileMap="{a7f6c8ef-3f0d-4400-b0ce-596a2c03d638}" units="mm" printResolution="300">
- <Snapper snapToItems="1" snapToGrid="0" tolerance="5" snapToGuides="1"/>
- <Grid resolution="10" offsetUnits="mm" resUnits="mm" offsetY="0" offsetX="0"/>
+<Layout name="CPLUS Report" printResolution="300" worldFileMap="{a7f6c8ef-3f0d-4400-b0ce-596a2c03d638}" units="mm">
+ <Snapper snapToItems="1" snapToGuides="1" tolerance="5" snapToGrid="0"/>
+ <Grid offsetY="0" offsetX="0" resUnits="mm" resolution="10" offsetUnits="mm"/>
  <PageCollection>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{c5f1dd4d-79e9-4806-a29f-1485f3f344bb}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{c5f1dd4d-79e9-4806-a29f-1485f3f344bb}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="255,255,255,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="35,35,35,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.26"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="255,255,255,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="35,35,35,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.26" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
-  <LayoutItem zValue="0" size="210,297,mm" referencePoint="0" id="" templateUuid="{231d5976-7eb4-4349-8b02-ee322d29c36a}" positionOnPage="0,0,mm" background="true" frameJoinStyle="miter" type="65638" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,0,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{231d5976-7eb4-4349-8b02-ee322d29c36a}" opacity="1" frame="false" excludeFromExports="0">
-   <FrameColor red="0" green="0" blue="0" alpha="255"/>
-   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutItem type="65638" blendMode="0" uuid="{9d7354b4-0ae3-4091-8ed5-6d89ed174f78}" positionLock="false" itemRotation="0" position="0,0,mm" zValue="0" templateUuid="{9d7354b4-0ae3-4091-8ed5-6d89ed174f78}" background="true" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0,0,mm" groupUuid="" id="" outlineWidthM="0.3,mm" referencePoint="0" size="210,297,mm">
+   <FrameColor red="0" alpha="255" green="0" blue="0"/>
+   <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
    <LayoutObject>
     <dataDefinedProperties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dataDefinedProperties>
     <customproperties>
      <Option/>
     </customproperties>
    </LayoutObject>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleFill" pass="0" enabled="1" id="{0b8f9fab-be9d-4b2d-8c5f-06bf99b656cb}" locked="0">
+    <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{0b8f9fab-be9d-4b2d-8c5f-06bf99b656cb}">
      <Option type="Map">
-      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="color" type="QString" value="255,255,255,255"/>
-      <Option name="joinstyle" type="QString" value="miter"/>
-      <Option name="offset" type="QString" value="0,0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="outline_color" type="QString" value="35,35,35,255"/>
-      <Option name="outline_style" type="QString" value="no"/>
-      <Option name="outline_width" type="QString" value="0.26"/>
-      <Option name="outline_width_unit" type="QString" value="MM"/>
-      <Option name="style" type="QString" value="solid"/>
+      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+      <Option value="255,255,255,255" name="color" type="QString"/>
+      <Option value="miter" name="joinstyle" type="QString"/>
+      <Option value="0,0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="35,35,35,255" name="outline_color" type="QString"/>
+      <Option value="no" name="outline_style" type="QString"/>
+      <Option value="0.26" name="outline_width" type="QString"/>
+      <Option value="MM" name="outline_width_unit" type="QString"/>
+      <Option value="solid" name="style" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </LayoutItem>
-  <LayoutItem zValue="0" size="210,297,mm" referencePoint="0" id="" templateUuid="{0f29ecee-a2e6-4a01-b458-00761bc1bdd8}" positionOnPage="0,0,mm" background="true" frameJoinStyle="miter" type="65638" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,307,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{0f29ecee-a2e6-4a01-b458-00761bc1bdd8}" opacity="1" frame="false" excludeFromExports="0">
-   <FrameColor red="0" green="0" blue="0" alpha="255"/>
-   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutItem type="65638" blendMode="0" uuid="{e2c3fbc9-d03b-4a30-b716-d20e55ab6847}" positionLock="false" itemRotation="0" position="0,307,mm" zValue="0" templateUuid="{e2c3fbc9-d03b-4a30-b716-d20e55ab6847}" background="true" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0,0,mm" groupUuid="" id="" outlineWidthM="0.3,mm" referencePoint="0" size="210,297,mm">
+   <FrameColor red="0" alpha="255" green="0" blue="0"/>
+   <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
    <LayoutObject>
     <dataDefinedProperties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dataDefinedProperties>
     <customproperties>
      <Option/>
     </customproperties>
    </LayoutObject>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleFill" pass="0" enabled="1" id="{fa834403-7cda-4451-8ee9-9ce2d44816e3}" locked="0">
+    <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{fa834403-7cda-4451-8ee9-9ce2d44816e3}">
      <Option type="Map">
-      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="color" type="QString" value="255,255,255,255"/>
-      <Option name="joinstyle" type="QString" value="miter"/>
-      <Option name="offset" type="QString" value="0,0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="outline_color" type="QString" value="35,35,35,255"/>
-      <Option name="outline_style" type="QString" value="no"/>
-      <Option name="outline_width" type="QString" value="0.26"/>
-      <Option name="outline_width_unit" type="QString" value="MM"/>
-      <Option name="style" type="QString" value="solid"/>
+      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+      <Option value="255,255,255,255" name="color" type="QString"/>
+      <Option value="miter" name="joinstyle" type="QString"/>
+      <Option value="0,0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="35,35,35,255" name="outline_color" type="QString"/>
+      <Option value="no" name="outline_style" type="QString"/>
+      <Option value="0.26" name="outline_width" type="QString"/>
+      <Option value="MM" name="outline_width_unit" type="QString"/>
+      <Option value="solid" name="style" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </LayoutItem>
   <GuideCollection visible="1">
-   <Guide page="0" orientation="2" units="mm" position="105.79424684213332"/>
-   <Guide page="1" orientation="2" units="mm" position="105.79424684213332"/>
+   <Guide orientation="2" page="0" position="105.79424684213332" units="mm"/>
+   <Guide orientation="2" page="1" position="105.79424684213332" units="mm"/>
   </GuideCollection>
  </PageCollection>
- <LayoutItem zValue="88" size="51.1961,48.0525,mm" sectionHeight="48.0525" referencePoint="4" id="assigned_weights_table" templateUuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" positionOnPage="158.054,248.512,mm" background="false" frameJoinStyle="miter" type="65647" sectionX="0" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" multiFrame="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" position="158.054,248.512,mm" visibility="1" itemRotation="0" sectionY="0" positionLock="false" uuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" multiFrameTemplateUuid="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" hidePageIfEmpty="0" opacity="1" sectionWidth="51.1961" hideBackgroundIfEmpty="0" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem sectionX="0" type="65647" blendMode="0" multiFrameTemplateUuid="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" uuid="{8e55e54e-d39a-42fd-9a22-944063807fd3}" positionLock="false" itemRotation="0" sectionHeight="48.0525" multiFrame="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" position="158.054,248.512,mm" hideBackgroundIfEmpty="0" zValue="88" templateUuid="{8e55e54e-d39a-42fd-9a22-944063807fd3}" sectionY="0" background="false" excludeFromExports="0" opacity="1" sectionWidth="51.1961" frame="false" frameJoinStyle="miter" hidePageIfEmpty="0" visibility="1" positionOnPage="158.054,248.512,mm" groupUuid="" id="assigned_weights_table" outlineWidthM="0.3,mm" referencePoint="4" size="51.1961,48.0525,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -148,21 +148,21 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="80" size="22.4124,21.0539,mm" referencePoint="0" resizeMode="0" id="title_logo_one" svgFillColor="255,255,255,255" templateUuid="{31715c90-a06e-477e-982d-7d47b2fd8d5f}" mode="0" positionOnPage="3.8525,2.58392,mm" background="true" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="21.0539" svgBorderWidth="0.2" mapUuid="" position="3.8525,2.58392,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{31715c90-a06e-477e-982d-7d47b2fd8d5f}" pictureHeight="21.0539" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65640" blendMode="0" uuid="{55a7108a-088a-4a95-987f-8cdb7adfe72a}" anchorPoint="0" positionLock="false" pictureWidth="21.0539" svgBorderWidth="0.2" itemRotation="0" pictureHeight="21.0539" position="3.8525,2.58392,mm" northOffset="0" zValue="80" templateUuid="{55a7108a-088a-4a95-987f-8cdb7adfe72a}" file="" northMode="0" background="true" excludeFromExports="0" resizeMode="0" svgBorderColor="0,0,0,255" opacity="1" svgFillColor="255,255,255,255" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="3.8525,2.58392,mm" groupUuid="" id="title_logo_one" outlineWidthM="0.3,mm" mode="0" referencePoint="0" size="22.4124,21.0539,mm" pictureRotation="0" mapUuid="">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option name="active" type="bool" value="true"/>
-       <Option name="expression" type="QString" value="@cplus_setting_cplus_logo"/>
-       <Option name="type" type="int" value="3"/>
+       <Option value="true" name="active" type="bool"/>
+       <Option value="@cplus_setting_cplus_logo" name="expression" type="QString"/>
+       <Option value="3" name="type" type="int"/>
       </Option>
      </Option>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -170,264 +170,264 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="79" size="176.922,12.3486,mm" referencePoint="0" id="heading_one_level_one_page_one" templateUuid="{c578549c-c230-473a-8dc5-b3f1dcba3af3}" positionOnPage="28.5781,2.58392,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="CPLUS Analysis Report&#xa;" position="28.5781,2.58392,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{c578549c-c230-473a-8dc5-b3f1dcba3af3}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="CPLUS Analysis Report&#xa;" uuid="{f9367475-88d9-492d-aedf-b537c1ce46bb}" positionLock="false" itemRotation="0" valign="32" position="28.5781,2.58392,mm" htmlState="0" halign="1" zValue="79" templateUuid="{f9367475-88d9-492d-aedf-b537c1ce46bb}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="28.5781,2.58392,mm" groupUuid="" id="heading_one_level_one_page_one" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="176.922,12.3486,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="28" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="28" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="angle" type="QString" value="0"/>
-       <Option name="cap_style" type="QString" value="square"/>
-       <Option name="color" type="QString" value="213,180,60,255"/>
-       <Option name="horizontal_anchor_point" type="QString" value="1"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="name" type="QString" value="circle"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="35,35,35,255"/>
-       <Option name="outline_style" type="QString" value="solid"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="scale_method" type="QString" value="diameter"/>
-       <Option name="size" type="QString" value="2"/>
-       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="size_unit" type="QString" value="MM"/>
-       <Option name="vertical_anchor_point" type="QString" value="1"/>
+       <Option value="0" name="angle" type="QString"/>
+       <Option value="square" name="cap_style" type="QString"/>
+       <Option value="213,180,60,255" name="color" type="QString"/>
+       <Option value="1" name="horizontal_anchor_point" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="circle" name="name" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="35,35,35,255" name="outline_color" type="QString"/>
+       <Option value="solid" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="diameter" name="scale_method" type="QString"/>
+       <Option value="2" name="size" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+       <Option value="MM" name="size_unit" type="QString"/>
+       <Option value="1" name="vertical_anchor_point" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="78" size="177.161,7.18097,mm" referencePoint="0" id="heading_two_level_two" templateUuid="{400e0bcf-47ab-49c1-be6a-44cffe7ee6eb}" positionOnPage="29.0377,16.4569,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_model_scenario_name %]" position="29.0377,16.4569,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{400e0bcf-47ab-49c1-be6a-44cffe7ee6eb}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="[% @cplus_model_scenario_name %]" uuid="{2bd0dfb9-e061-44b4-a0d8-d750d1e5ae2c}" positionLock="false" itemRotation="0" valign="32" position="29.0377,16.4569,mm" htmlState="0" halign="1" zValue="78" templateUuid="{2bd0dfb9-e061-44b4-a0d8-d750d1e5ae2c}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="29.0377,16.4569,mm" groupUuid="" id="heading_two_level_two" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="177.161,7.18097,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="18" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="18" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="angle" type="QString" value="0"/>
-       <Option name="cap_style" type="QString" value="square"/>
-       <Option name="color" type="QString" value="213,180,60,255"/>
-       <Option name="horizontal_anchor_point" type="QString" value="1"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="name" type="QString" value="circle"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="35,35,35,255"/>
-       <Option name="outline_style" type="QString" value="solid"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="scale_method" type="QString" value="diameter"/>
-       <Option name="size" type="QString" value="2"/>
-       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="size_unit" type="QString" value="MM"/>
-       <Option name="vertical_anchor_point" type="QString" value="1"/>
+       <Option value="0" name="angle" type="QString"/>
+       <Option value="square" name="cap_style" type="QString"/>
+       <Option value="213,180,60,255" name="color" type="QString"/>
+       <Option value="1" name="horizontal_anchor_point" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="circle" name="name" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="35,35,35,255" name="outline_color" type="QString"/>
+       <Option value="solid" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="diameter" name="scale_method" type="QString"/>
+       <Option value="2" name="size" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+       <Option value="MM" name="size_unit" type="QString"/>
+       <Option value="1" name="vertical_anchor_point" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="77" cornerRadiusMeasure="0,mm" size="210,25.8685,mm" shapeType="1" referencePoint="0" id="heading_background_one" templateUuid="{c26ca896-9600-40ba-a063-8e2c61920a4a}" positionOnPage="0,0,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,0,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{c26ca896-9600-40ba-a063-8e2c61920a4a}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{3255ea7e-9cad-443f-9676-bf25b442bab1}" positionLock="false" shapeType="1" itemRotation="0" position="0,0,mm" zValue="77" templateUuid="{3255ea7e-9cad-443f-9676-bf25b442bab1}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0,0,mm" groupUuid="" id="heading_background_one" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210,25.8685,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="3,109,0,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="3,109,0,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="76" size="6.31047,6.72239,mm" referencePoint="0" resizeMode="0" id="north_arrow_one" svgFillColor="255,255,255,255" templateUuid="{fc61f03d-ca85-4ce1-86c7-a202e88a17f0}" mode="2" positionOnPage="180.049,167.814,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="5.32553" svgBorderWidth="0.2" mapUuid="" position="180.049,167.814,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file=":/images/north_arrows/layout_default_north_arrow.svg" northOffset="0" svgBorderColor="0,0,0,255" uuid="{fc61f03d-ca85-4ce1-86c7-a202e88a17f0}" pictureHeight="6.72239" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65640" blendMode="0" uuid="{7e11f674-7ba6-4564-9903-650eeb30a20e}" anchorPoint="0" positionLock="false" pictureWidth="5.32553" svgBorderWidth="0.2" itemRotation="0" pictureHeight="6.72239" position="180.049,167.814,mm" northOffset="0" zValue="76" templateUuid="{7e11f674-7ba6-4564-9903-650eeb30a20e}" file=":/images/north_arrows/layout_default_north_arrow.svg" northMode="0" background="false" excludeFromExports="0" resizeMode="0" svgBorderColor="0,0,0,255" opacity="1" svgFillColor="255,255,255,255" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="180.049,167.814,mm" groupUuid="" id="north_arrow_one" outlineWidthM="0.3,mm" mode="2" referencePoint="0" size="6.31047,6.72239,mm" pictureRotation="0" mapUuid="">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -435,304 +435,304 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem lineCapStyle="square" numSegmentsLeft="0" numMapUnitsPerScaleBarUnit="1" minBarWidth="20" templateUuid="{22d9295f-3ae7-4686-8797-da94b8b0f2fa}" zValue="75" mapUuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" height="2" labelHorizontalPlacement="1" id="scalebar_map_one" labelVerticalPlacement="0" boxContentSpace="1" frameJoinStyle="miter" labelBarSpace="1" unitType="km" numUnitsPerSegment="9" alignment="0" excludeFromExports="0" background="true" frame="false" visibility="1" segmentSizeMode="1" maxBarWidth="40" unitLabel="km" numSubdivisions="1" size="40.3232,9.33,mm" positionLock="false" referencePoint="4" type="65646" itemRotation="0" outlineWidthM="0.3,mm" opacity="1" position="183.204,181.302,mm" uuid="{22d9295f-3ae7-4686-8797-da94b8b0f2fa}" style="Single Box" lineJoinStyle="miter" groupUuid="" outlineWidth="0.3" subdivisionsHeight="1.5" blendMode="0" numSegments="2" segmentMillimeters="18.8616" positionOnPage="183.204,181.302,mm">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="181"/>
+ <LayoutItem maxBarWidth="40" groupUuid="" itemRotation="0" style="Single Box" mapUuid="{a0bd8b99-56d9-43a1-a007-09cdce5f8a16}" segmentSizeMode="1" segmentMillimeters="18.8616" frame="false" labelVerticalPlacement="0" referencePoint="4" unitType="km" outlineWidthM="0.3,mm" type="65646" blendMode="0" numMapUnitsPerScaleBarUnit="1" alignment="0" background="true" excludeFromExports="0" numSegmentsLeft="0" position="183.204,181.302,mm" numUnitsPerSegment="9" frameJoinStyle="miter" boxContentSpace="1" lineCapStyle="square" numSubdivisions="1" id="scalebar_map_one" minBarWidth="20" size="40.3232,9.33,mm" positionLock="false" outlineWidth="0.3" templateUuid="{fd197c33-5629-4011-acc3-c2c26b42745a}" opacity="1" zValue="75" lineJoinStyle="miter" visibility="1" uuid="{fd197c33-5629-4011-acc3-c2c26b42745a}" positionOnPage="183.204,181.302,mm" unitLabel="km" numSegments="2" labelHorizontalPlacement="1" height="2" subdivisionsHeight="1.5" labelBarSpace="1">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="181" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="8" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="8" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
-  <strokeColor red="0" green="0" blue="0" alpha="255"/>
+  <strokeColor red="0" alpha="255" green="0" blue="0"/>
   <numericFormat id="basic">
    <Option type="Map">
     <Option name="decimal_separator" type="invalid"/>
-    <Option name="decimals" type="int" value="6"/>
-    <Option name="rounding_type" type="int" value="0"/>
-    <Option name="show_plus" type="bool" value="false"/>
-    <Option name="show_thousand_separator" type="bool" value="true"/>
-    <Option name="show_trailing_zeros" type="bool" value="false"/>
+    <Option value="6" name="decimals" type="int"/>
+    <Option value="0" name="rounding_type" type="int"/>
+    <Option value="false" name="show_plus" type="bool"/>
+    <Option value="true" name="show_thousand_separator" type="bool"/>
+    <Option value="false" name="show_trailing_zeros" type="bool"/>
     <Option name="thousand_separator" type="invalid"/>
    </Option>
   </numericFormat>
-  <fillColor red="0" green="0" blue="0" alpha="255"/>
-  <fillColor2 red="255" green="255" blue="255" alpha="255"/>
+  <fillColor red="0" alpha="255" green="0" blue="0"/>
+  <fillColor2 red="255" alpha="255" green="255" blue="255"/>
   <lineSymbol>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="line" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
+    <layer pass="0" class="SimpleLine" enabled="1" locked="0" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
      <Option type="Map">
-      <Option name="align_dash_pattern" type="QString" value="0"/>
-      <Option name="capstyle" type="QString" value="square"/>
-      <Option name="customdash" type="QString" value="5;2"/>
-      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="customdash_unit" type="QString" value="MM"/>
-      <Option name="dash_pattern_offset" type="QString" value="0"/>
-      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-      <Option name="draw_inside_polygon" type="QString" value="0"/>
-      <Option name="joinstyle" type="QString" value="miter"/>
-      <Option name="line_color" type="QString" value="0,0,0,255"/>
-      <Option name="line_style" type="QString" value="solid"/>
-      <Option name="line_width" type="QString" value="0.3"/>
-      <Option name="line_width_unit" type="QString" value="MM"/>
-      <Option name="offset" type="QString" value="0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="ring_filter" type="QString" value="0"/>
-      <Option name="trim_distance_end" type="QString" value="0"/>
-      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-      <Option name="trim_distance_start" type="QString" value="0"/>
-      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-      <Option name="use_custom_dash" type="QString" value="0"/>
-      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option value="0" name="align_dash_pattern" type="QString"/>
+      <Option value="square" name="capstyle" type="QString"/>
+      <Option value="5;2" name="customdash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+      <Option value="MM" name="customdash_unit" type="QString"/>
+      <Option value="0" name="dash_pattern_offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+      <Option value="0" name="draw_inside_polygon" type="QString"/>
+      <Option value="miter" name="joinstyle" type="QString"/>
+      <Option value="0,0,0,255" name="line_color" type="QString"/>
+      <Option value="solid" name="line_style" type="QString"/>
+      <Option value="0.3" name="line_width" type="QString"/>
+      <Option value="MM" name="line_width_unit" type="QString"/>
+      <Option value="0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="0" name="ring_filter" type="QString"/>
+      <Option value="0" name="trim_distance_end" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+      <Option value="0" name="trim_distance_start" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+      <Option value="0" name="use_custom_dash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </lineSymbol>
   <divisionLineSymbol>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="line" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
+    <layer pass="0" class="SimpleLine" enabled="1" locked="0" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
      <Option type="Map">
-      <Option name="align_dash_pattern" type="QString" value="0"/>
-      <Option name="capstyle" type="QString" value="square"/>
-      <Option name="customdash" type="QString" value="5;2"/>
-      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="customdash_unit" type="QString" value="MM"/>
-      <Option name="dash_pattern_offset" type="QString" value="0"/>
-      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-      <Option name="draw_inside_polygon" type="QString" value="0"/>
-      <Option name="joinstyle" type="QString" value="miter"/>
-      <Option name="line_color" type="QString" value="0,0,0,255"/>
-      <Option name="line_style" type="QString" value="solid"/>
-      <Option name="line_width" type="QString" value="0.3"/>
-      <Option name="line_width_unit" type="QString" value="MM"/>
-      <Option name="offset" type="QString" value="0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="ring_filter" type="QString" value="0"/>
-      <Option name="trim_distance_end" type="QString" value="0"/>
-      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-      <Option name="trim_distance_start" type="QString" value="0"/>
-      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-      <Option name="use_custom_dash" type="QString" value="0"/>
-      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option value="0" name="align_dash_pattern" type="QString"/>
+      <Option value="square" name="capstyle" type="QString"/>
+      <Option value="5;2" name="customdash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+      <Option value="MM" name="customdash_unit" type="QString"/>
+      <Option value="0" name="dash_pattern_offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+      <Option value="0" name="draw_inside_polygon" type="QString"/>
+      <Option value="miter" name="joinstyle" type="QString"/>
+      <Option value="0,0,0,255" name="line_color" type="QString"/>
+      <Option value="solid" name="line_style" type="QString"/>
+      <Option value="0.3" name="line_width" type="QString"/>
+      <Option value="MM" name="line_width_unit" type="QString"/>
+      <Option value="0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="0" name="ring_filter" type="QString"/>
+      <Option value="0" name="trim_distance_end" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+      <Option value="0" name="trim_distance_start" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+      <Option value="0" name="use_custom_dash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </divisionLineSymbol>
   <subdivisionLineSymbol>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="line" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
+    <layer pass="0" class="SimpleLine" enabled="1" locked="0" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
      <Option type="Map">
-      <Option name="align_dash_pattern" type="QString" value="0"/>
-      <Option name="capstyle" type="QString" value="square"/>
-      <Option name="customdash" type="QString" value="5;2"/>
-      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="customdash_unit" type="QString" value="MM"/>
-      <Option name="dash_pattern_offset" type="QString" value="0"/>
-      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-      <Option name="draw_inside_polygon" type="QString" value="0"/>
-      <Option name="joinstyle" type="QString" value="miter"/>
-      <Option name="line_color" type="QString" value="0,0,0,255"/>
-      <Option name="line_style" type="QString" value="solid"/>
-      <Option name="line_width" type="QString" value="0.3"/>
-      <Option name="line_width_unit" type="QString" value="MM"/>
-      <Option name="offset" type="QString" value="0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="ring_filter" type="QString" value="0"/>
-      <Option name="trim_distance_end" type="QString" value="0"/>
-      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-      <Option name="trim_distance_start" type="QString" value="0"/>
-      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-      <Option name="use_custom_dash" type="QString" value="0"/>
-      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option value="0" name="align_dash_pattern" type="QString"/>
+      <Option value="square" name="capstyle" type="QString"/>
+      <Option value="5;2" name="customdash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+      <Option value="MM" name="customdash_unit" type="QString"/>
+      <Option value="0" name="dash_pattern_offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+      <Option value="0" name="draw_inside_polygon" type="QString"/>
+      <Option value="miter" name="joinstyle" type="QString"/>
+      <Option value="0,0,0,255" name="line_color" type="QString"/>
+      <Option value="solid" name="line_style" type="QString"/>
+      <Option value="0.3" name="line_width" type="QString"/>
+      <Option value="MM" name="line_width_unit" type="QString"/>
+      <Option value="0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="0" name="ring_filter" type="QString"/>
+      <Option value="0" name="trim_distance_end" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+      <Option value="0" name="trim_distance_start" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+      <Option value="0" name="use_custom_dash" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </subdivisionLineSymbol>
   <fillSymbol1>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleFill" pass="0" enabled="1" id="{5e8caacb-d09f-4173-92cf-6ae80d1ca6ee}" locked="0">
+    <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{5e8caacb-d09f-4173-92cf-6ae80d1ca6ee}">
      <Option type="Map">
-      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="color" type="QString" value="0,0,0,255"/>
-      <Option name="joinstyle" type="QString" value="bevel"/>
-      <Option name="offset" type="QString" value="0,0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="outline_color" type="QString" value="35,35,35,255"/>
-      <Option name="outline_style" type="QString" value="no"/>
-      <Option name="outline_width" type="QString" value="0.26"/>
-      <Option name="outline_width_unit" type="QString" value="MM"/>
-      <Option name="style" type="QString" value="solid"/>
+      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+      <Option value="0,0,0,255" name="color" type="QString"/>
+      <Option value="bevel" name="joinstyle" type="QString"/>
+      <Option value="0,0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="35,35,35,255" name="outline_color" type="QString"/>
+      <Option value="no" name="outline_style" type="QString"/>
+      <Option value="0.26" name="outline_width" type="QString"/>
+      <Option value="MM" name="outline_width_unit" type="QString"/>
+      <Option value="solid" name="style" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </fillSymbol1>
   <fillSymbol2>
-   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
-    <layer class="SimpleFill" pass="0" enabled="1" id="{60d585c6-c72a-42d3-8050-d0102f88ce38}" locked="0">
+    <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{60d585c6-c72a-42d3-8050-d0102f88ce38}">
      <Option type="Map">
-      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="color" type="QString" value="255,255,255,255"/>
-      <Option name="joinstyle" type="QString" value="bevel"/>
-      <Option name="offset" type="QString" value="0,0"/>
-      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-      <Option name="offset_unit" type="QString" value="MM"/>
-      <Option name="outline_color" type="QString" value="35,35,35,255"/>
-      <Option name="outline_style" type="QString" value="no"/>
-      <Option name="outline_width" type="QString" value="0.26"/>
-      <Option name="outline_width_unit" type="QString" value="MM"/>
-      <Option name="style" type="QString" value="solid"/>
+      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+      <Option value="255,255,255,255" name="color" type="QString"/>
+      <Option value="bevel" name="joinstyle" type="QString"/>
+      <Option value="0,0" name="offset" type="QString"/>
+      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+      <Option value="MM" name="offset_unit" type="QString"/>
+      <Option value="35,35,35,255" name="outline_color" type="QString"/>
+      <Option value="no" name="outline_style" type="QString"/>
+      <Option value="0.26" name="outline_width" type="QString"/>
+      <Option value="MM" name="outline_width_unit" type="QString"/>
+      <Option value="solid" name="style" type="QString"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </fillSymbol2>
  </LayoutItem>
- <LayoutItem legendFilterByAtlas="0" symbolAlignment="1" rasterBorderColor="0,0,0,255" legendFilterByMap="1" templateUuid="{decb0471-87d4-4984-a05d-49611a711c88}" zValue="74" splitLayer="1" wrapChar="" id="legend_main_map" frameJoinStyle="miter" resizeToContents="0" symbolWidth="3" map_uuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" wmsLegendWidth="50" columnSpace="2" title="" excludeFromExports="0" background="true" frame="false" rasterBorder="1" visibility="1" minSymbolSize="0" size="75.3434,94.0442,mm" positionLock="false" referencePoint="0" type="65642" itemRotation="0" titleAlignment="1" outlineWidthM="0.3,mm" opacity="1" position="134.655,25.8685,mm" uuid="{decb0471-87d4-4984-a05d-49611a711c88}" wmsLegendHeight="25" symbolHeight="3" rasterBorderWidth="0" boxSpace="2" columnCount="1" groupUuid="" blendMode="0" equalColumnWidth="0" positionOnPage="134.655,25.8685,mm" maxSymbolSize="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="185"/>
+ <LayoutItem groupUuid="" wmsLegendWidth="50" itemRotation="0" symbolWidth="3" frame="false" wmsLegendHeight="25" minSymbolSize="0" resizeToContents="0" title="" referencePoint="0" outlineWidthM="0.3,mm" type="65642" blendMode="0" background="true" excludeFromExports="0" titleAlignment="1" map_uuid="{a0bd8b99-56d9-43a1-a007-09cdce5f8a16}" equalColumnWidth="0" position="138.02,25.8685,mm" rasterBorderWidth="0" wrapChar="" columnSpace="2" maxSymbolSize="0" rasterBorder="1" frameJoinStyle="miter" boxSpace="2" id="legend_main_map" legendFilterByMap="1" size="71.9785,94.0442,mm" positionLock="false" templateUuid="{7d42fb9f-3b2e-4c9b-b315-4f92be6f5747}" opacity="1" rasterBorderColor="0,0,0,255" zValue="74" symbolAlignment="1" legendFilterByAtlas="0" visibility="1" uuid="{7d42fb9f-3b2e-4c9b-b315-4f92be6f5747}" positionOnPage="138.02,25.8685,mm" columnCount="1" splitLayer="1" symbolHeight="3">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="185" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -740,769 +740,769 @@
    </customproperties>
   </LayoutObject>
   <styles>
-   <style name="title" alignment="1" indent="0">
-    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="14" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="75" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Bold" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <style name="title" indent="0" alignment="1">
+    <text-style multilineHeight="1.1000000000000001" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="14" namedStyle="Bold" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="75" fontSizeUnit="Point">
      <families/>
-     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-      <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+     <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+     <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+     <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+      <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="angle" type="QString" value="0"/>
-         <Option name="cap_style" type="QString" value="square"/>
-         <Option name="color" type="QString" value="164,113,88,255"/>
-         <Option name="horizontal_anchor_point" type="QString" value="1"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="name" type="QString" value="circle"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="35,35,35,255"/>
-         <Option name="outline_style" type="QString" value="solid"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="scale_method" type="QString" value="diameter"/>
-         <Option name="size" type="QString" value="2"/>
-         <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="size_unit" type="QString" value="MM"/>
-         <Option name="vertical_anchor_point" type="QString" value="1"/>
+         <Option value="0" name="angle" type="QString"/>
+         <Option value="square" name="cap_style" type="QString"/>
+         <Option value="164,113,88,255" name="color" type="QString"/>
+         <Option value="1" name="horizontal_anchor_point" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="circle" name="name" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="35,35,35,255" name="outline_color" type="QString"/>
+         <Option value="solid" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="diameter" name="scale_method" type="QString"/>
+         <Option value="2" name="size" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+         <Option value="MM" name="size_unit" type="QString"/>
+         <Option value="1" name="vertical_anchor_point" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
-      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+      <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="color" type="QString" value="255,255,255,255"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="128,128,128,255"/>
-         <Option name="outline_style" type="QString" value="no"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="style" type="QString" value="solid"/>
+         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+         <Option value="255,255,255,255" name="color" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="128,128,128,255" name="outline_color" type="QString"/>
+         <Option value="no" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="solid" name="style" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+     <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
      <dd_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="group" alignment="1" indent="0">
-    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="0" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <style name="group" indent="0" alignment="1">
+    <text-style multilineHeight="1.1000000000000001" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="0" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
      <families/>
-     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+     <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+     <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+      <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="color" type="QString" value="255,255,255,255"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="128,128,128,255"/>
-         <Option name="outline_style" type="QString" value="no"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="style" type="QString" value="solid"/>
+         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+         <Option value="255,255,255,255" name="color" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="128,128,128,255" name="outline_color" type="QString"/>
+         <Option value="no" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="solid" name="style" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+     <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
      <dd_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="subgroup" alignment="1" indent="0">
-    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="16" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="75" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Bold" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <style name="subgroup" indent="0" alignment="1">
+    <text-style multilineHeight="1.1000000000000001" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="16" namedStyle="Bold" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="75" fontSizeUnit="Point">
      <families/>
-     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-      <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+     <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+     <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+     <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+      <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="angle" type="QString" value="0"/>
-         <Option name="cap_style" type="QString" value="square"/>
-         <Option name="color" type="QString" value="255,158,23,255"/>
-         <Option name="horizontal_anchor_point" type="QString" value="1"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="name" type="QString" value="circle"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="35,35,35,255"/>
-         <Option name="outline_style" type="QString" value="solid"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="scale_method" type="QString" value="diameter"/>
-         <Option name="size" type="QString" value="2"/>
-         <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="size_unit" type="QString" value="MM"/>
-         <Option name="vertical_anchor_point" type="QString" value="1"/>
+         <Option value="0" name="angle" type="QString"/>
+         <Option value="square" name="cap_style" type="QString"/>
+         <Option value="255,158,23,255" name="color" type="QString"/>
+         <Option value="1" name="horizontal_anchor_point" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="circle" name="name" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="35,35,35,255" name="outline_color" type="QString"/>
+         <Option value="solid" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="diameter" name="scale_method" type="QString"/>
+         <Option value="2" name="size" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+         <Option value="MM" name="size_unit" type="QString"/>
+         <Option value="1" name="vertical_anchor_point" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
-      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+      <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="color" type="QString" value="255,255,255,255"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="128,128,128,255"/>
-         <Option name="outline_style" type="QString" value="no"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="style" type="QString" value="solid"/>
+         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+         <Option value="255,255,255,255" name="color" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="128,128,128,255" name="outline_color" type="QString"/>
+         <Option value="no" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="solid" name="style" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+     <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
      <dd_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style marginTop="2.5" name="symbol" alignment="1" indent="0">
-    <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="10" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <style name="symbol" indent="0" alignment="1" marginTop="2.5">
+    <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="10" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
      <families/>
-     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+     <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+     <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+      <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="color" type="QString" value="255,255,255,255"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="128,128,128,255"/>
-         <Option name="outline_style" type="QString" value="no"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="style" type="QString" value="solid"/>
+         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+         <Option value="255,255,255,255" name="color" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="128,128,128,255" name="outline_color" type="QString"/>
+         <Option value="no" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="solid" name="style" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+     <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
      <dd_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style marginTop="2" name="symbolLabel" alignment="1" indent="0" marginLeft="2">
-    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="8" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <style name="symbolLabel" indent="0" alignment="1" marginTop="2" marginLeft="2">
+    <text-style multilineHeight="1.1000000000000001" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="8" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
      <families/>
-     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+     <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+     <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+      <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
-       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+       <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
         <Option type="Map">
-         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="color" type="QString" value="255,255,255,255"/>
-         <Option name="joinstyle" type="QString" value="bevel"/>
-         <Option name="offset" type="QString" value="0,0"/>
-         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-         <Option name="offset_unit" type="QString" value="MM"/>
-         <Option name="outline_color" type="QString" value="128,128,128,255"/>
-         <Option name="outline_style" type="QString" value="no"/>
-         <Option name="outline_width" type="QString" value="0"/>
-         <Option name="outline_width_unit" type="QString" value="MM"/>
-         <Option name="style" type="QString" value="solid"/>
+         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+         <Option value="255,255,255,255" name="color" type="QString"/>
+         <Option value="bevel" name="joinstyle" type="QString"/>
+         <Option value="0,0" name="offset" type="QString"/>
+         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+         <Option value="MM" name="offset_unit" type="QString"/>
+         <Option value="128,128,128,255" name="outline_color" type="QString"/>
+         <Option value="no" name="outline_style" type="QString"/>
+         <Option value="0" name="outline_width" type="QString"/>
+         <Option value="MM" name="outline_width_unit" type="QString"/>
+         <Option value="solid" name="style" type="QString"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option name="name" type="QString" value=""/>
+          <Option value="" name="name" type="QString"/>
           <Option name="properties"/>
-          <Option name="type" type="QString" value="collection"/>
+          <Option value="collection" name="type" type="QString"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+     <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
      <dd_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
   </styles>
  </LayoutItem>
- <LayoutItem zValue="73" size="210.014,160.099,mm" labelMargin="0,mm" referencePoint="0" id="map_one_scenario" templateUuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" positionOnPage="0,25.8685,mm" background="true" frameJoinStyle="miter" mapRotation="0" type="65639" mapFlags="0" groupUuid="" blendMode="0" followPresetName="Final Scenario" outlineWidthM="0.3,mm" drawCanvasItems="true" keepLayerSet="false" position="0,25.8685,mm" isTemporal="0" visibility="1" itemRotation="0" positionLock="false" uuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" opacity="1" frame="false" excludeFromExports="0" followPreset="true">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem drawCanvasItems="true" mapRotation="0" type="65639" blendMode="0" uuid="{a0bd8b99-56d9-43a1-a007-09cdce5f8a16}" positionLock="false" followPreset="true" itemRotation="0" position="0,25.8685,mm" keepLayerSet="false" followPresetName="Final Scenario" labelMargin="0,mm" zValue="73" templateUuid="{a0bd8b99-56d9-43a1-a007-09cdce5f8a16}" background="true" excludeFromExports="0" opacity="1" mapFlags="0" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0,25.8685,mm" groupUuid="" id="map_one_scenario" outlineWidthM="0.3,mm" isTemporal="0" referencePoint="0" size="210.014,160.099,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <Extent xmin="30.53573927524800524" ymin="-25.23811207252041555" ymax="-24.47990663749100904" xmax="31.53033795188935784"/>
+  <Extent xmin="30.53573927524800524" ymax="-24.47990663749100904" ymin="-25.23811207252041555" xmax="31.53033795188935784"/>
   <LayerSet/>
-  <AtlasMap scalingMode="2" atlasDriven="0" margin="0.10000000000000001"/>
+  <AtlasMap margin="0.10000000000000001" atlasDriven="0" scalingMode="2"/>
   <labelBlockingItems/>
-  <atlasClippingSettings clippingType="1" forceLabelsInside="0" restrictLayers="0" enabled="0">
+  <atlasClippingSettings restrictLayers="0" forceLabelsInside="0" enabled="0" clippingType="1">
    <layersToClip/>
   </atlasClippingSettings>
-  <itemClippingSettings clippingType="1" forceLabelsInside="0" clipSource="" enabled="0"/>
+  <itemClippingSettings forceLabelsInside="0" enabled="0" clippingType="1" clipSource=""/>
  </LayoutItem>
- <LayoutItem zValue="72" size="210.362,11.5546,mm" referencePoint="0" id="heading_three_level_three" templateUuid="{538f9125-82fa-4f2e-8e4a-b6fa5691ec4b}" positionOnPage="-0.36335,185.967,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Summary" position="-0.36335,185.967,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{538f9125-82fa-4f2e-8e4a-b6fa5691ec4b}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="Scenario Summary" uuid="{e7b3afdd-8bc3-4a43-a557-d641275024c4}" positionLock="false" itemRotation="0" valign="128" position="-0.36335,185.967,mm" htmlState="0" halign="4" zValue="72" templateUuid="{e7b3afdd-8bc3-4a43-a557-d641275024c4}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="-0.36335,185.967,mm" groupUuid="" id="heading_three_level_three" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="210.362,11.5546,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="17" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="17" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="71" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm" shapeType="1" referencePoint="0" id="heading_background_two" templateUuid="{138b6be8-9ecd-4578-a677-652d43e328f1}" positionOnPage="-0.02595,185.967,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-0.02595,185.967,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{138b6be8-9ecd-4578-a677-652d43e328f1}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{468bc8ae-3e32-4090-993a-df15283d6005}" positionLock="false" shapeType="1" itemRotation="0" position="-0.02595,185.967,mm" zValue="71" templateUuid="{468bc8ae-3e32-4090-993a-df15283d6005}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="-0.02595,185.967,mm" groupUuid="" id="heading_background_two" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="3,109,0,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="3,109,0,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="70" size="210,13.799,mm" referencePoint="0" id="scenario_description" templateUuid="{f150520a-9cc5-4085-be5c-92638b682547}" positionOnPage="0.01394,197.522,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="1" valign="32" labelText="[% @cplus_model_scenario_description %]" position="0.01394,197.522,mm" visibility="1" itemRotation="0" marginY="0.5" positionLock="false" halign="1" uuid="{f150520a-9cc5-4085-be5c-92638b682547}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="1" labelText="[% @cplus_model_scenario_description %]" uuid="{d9b631fb-068a-468c-83a4-b86f12a847b5}" positionLock="false" itemRotation="0" valign="32" position="0.01394,197.522,mm" htmlState="0" halign="1" zValue="70" templateUuid="{d9b631fb-068a-468c-83a4-b86f12a847b5}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0.01394,197.522,mm" groupUuid="" id="scenario_description" outlineWidthM="0.3,mm" referencePoint="0" marginY="0.5" size="210,13.799,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="11" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="11" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="69" size="105.78,11.5546,mm" referencePoint="0" id="heading_four_left" templateUuid="{b1793ad7-f1b0-4d56-93bb-b1ab3e256833}" positionOnPage="0.01394,211.321,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Summary Statistics" position="0.01394,211.321,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{b1793ad7-f1b0-4d56-93bb-b1ab3e256833}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="Scenario Summary Statistics" uuid="{952c8fc8-9fda-4744-a8eb-84a3e727e609}" positionLock="false" itemRotation="0" valign="128" position="0.01394,211.321,mm" htmlState="0" halign="4" zValue="69" templateUuid="{952c8fc8-9fda-4744-a8eb-84a3e727e609}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0.01394,211.321,mm" groupUuid="" id="heading_four_left" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="105.78,11.5546,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="13" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="13" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="68" size="104.52,11.5546,mm" referencePoint="0" id="heading_four_right" templateUuid="{2579db44-1aff-4620-ae69-1e8e0a1402d1}" positionOnPage="105.794,211.321,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Weighting Values" position="105.794,211.321,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{2579db44-1aff-4620-ae69-1e8e0a1402d1}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="Scenario Weighting Values" uuid="{d5620a88-8c95-4a0a-b24b-6fb265d20c12}" positionLock="false" itemRotation="0" valign="128" position="105.794,211.321,mm" htmlState="0" halign="4" zValue="68" templateUuid="{d5620a88-8c95-4a0a-b24b-6fb265d20c12}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="105.794,211.321,mm" groupUuid="" id="heading_four_right" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="104.52,11.5546,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="13" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="13" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="67" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm" shapeType="1" referencePoint="0" id="heading_background_three" templateUuid="{b278f8e7-2751-44b6-9798-d4c9ba2c4653}" positionOnPage="0.01394,211.321,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0.01394,211.321,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{b278f8e7-2751-44b6-9798-d4c9ba2c4653}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{51bd353b-7205-4266-a0a4-edd664088734}" positionLock="false" shapeType="1" itemRotation="0" position="0.01394,211.321,mm" zValue="67" templateUuid="{51bd353b-7205-4266-a0a4-edd664088734}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0.01394,211.321,mm" groupUuid="" id="heading_background_three" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="178,223,138,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="178,223,138,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="59" size="167.683,15.6086,mm" referencePoint="0" id="accreditation_text" templateUuid="{3465f3e9-2f63-4b76-8ffd-b8997aa3fc01}" positionOnPage="2.76111,279.287,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" position="2.76111,279.287,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{3465f3e9-2f63-4b76-8ffd-b8997aa3fc01}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="[% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" uuid="{63293882-bc5a-476a-b57b-6a20f3b0d407}" positionLock="false" itemRotation="0" valign="32" position="2.76111,279.287,mm" htmlState="0" halign="1" zValue="59" templateUuid="{63293882-bc5a-476a-b57b-6a20f3b0d407}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="2.76111,279.287,mm" groupUuid="" id="accreditation_text" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="167.683,15.6086,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="7.5" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="7.5" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="57" size="37.1491,14.1884,mm" referencePoint="0" resizeMode="0" id="logo_2" svgFillColor="255,255,255,255" templateUuid="{83465577-91a1-46be-b7ab-59eb0f4371c5}" mode="0" positionOnPage="171.763,279.287,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="34.0522" svgBorderWidth="0.2" mapUuid="" position="171.763,279.287,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{83465577-91a1-46be-b7ab-59eb0f4371c5}" pictureHeight="14.1884" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65640" blendMode="0" uuid="{ff0b72db-f01b-4ebf-9ec7-3c99a9b1b4f4}" anchorPoint="0" positionLock="false" pictureWidth="34.0522" svgBorderWidth="0.2" itemRotation="0" pictureHeight="14.1884" position="171.763,279.287,mm" northOffset="0" zValue="57" templateUuid="{ff0b72db-f01b-4ebf-9ec7-3c99a9b1b4f4}" file="" northMode="0" background="false" excludeFromExports="0" resizeMode="0" svgBorderColor="0,0,0,255" opacity="1" svgFillColor="255,255,255,255" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="171.763,279.287,mm" groupUuid="" id="logo_2" outlineWidthM="0.3,mm" mode="0" referencePoint="0" size="37.1491,14.1884,mm" pictureRotation="0" mapUuid="">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option name="active" type="bool" value="true"/>
-       <Option name="expression" type="QString" value="@cplus_setting_ci_logo"/>
-       <Option name="type" type="int" value="3"/>
+       <Option value="true" name="active" type="bool"/>
+       <Option value="@cplus_setting_ci_logo" name="expression" type="QString"/>
+       <Option value="3" name="type" type="int"/>
       </Option>
      </Option>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1510,130 +1510,130 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="56" size="3.62469,4.75988,mm" referencePoint="0" id="page_number_1" templateUuid="{cb4656f7-9f0e-420b-a4a7-d5e6212ade9f}" positionOnPage="103.982,291.095,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @layout_page %]" position="103.982,291.095,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{cb4656f7-9f0e-420b-a4a7-d5e6212ade9f}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="[% @layout_page %]" uuid="{e741711e-f002-4a59-9b6d-de703371f603}" positionLock="false" itemRotation="0" valign="32" position="103.982,291.095,mm" htmlState="0" halign="1" zValue="56" templateUuid="{e741711e-f002-4a59-9b6d-de703371f603}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="103.982,291.095,mm" groupUuid="" id="page_number_1" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="3.62469,4.75988,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="12" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="55" cornerRadiusMeasure="0,mm" size="210,21.238,mm" shapeType="1" referencePoint="0" id="footer_background" templateUuid="{b163af01-a421-4062-a00c-962da034fc1f}" positionOnPage="0.01394,275.762,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0.01394,275.762,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{b163af01-a421-4062-a00c-962da034fc1f}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{6bcfce83-1acd-4bd0-add0-74f6560f6a2b}" positionLock="false" shapeType="1" itemRotation="0" position="0.01394,275.762,mm" zValue="55" templateUuid="{6bcfce83-1acd-4bd0-add0-74f6560f6a2b}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="0.01394,275.762,mm" groupUuid="" id="footer_background" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210,21.238,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="3,109,0,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="3,109,0,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="54" size="22.4124,21.0539,mm" referencePoint="0" resizeMode="0" id="title_logo_two" svgFillColor="255,255,255,255" templateUuid="{e7663c22-2f85-4e4e-8679-0ce82ba72f89}" mode="0" positionOnPage="3.8525,2.584,mm" background="true" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="21.0539" svgBorderWidth="0.2" mapUuid="" position="3.8525,309.584,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{e7663c22-2f85-4e4e-8679-0ce82ba72f89}" pictureHeight="21.0539" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65640" blendMode="0" uuid="{b2c30ce3-e436-42fb-a861-49e4e2644859}" anchorPoint="0" positionLock="false" pictureWidth="21.0539" svgBorderWidth="0.2" itemRotation="0" pictureHeight="21.0539" position="3.8525,309.584,mm" northOffset="0" zValue="54" templateUuid="{b2c30ce3-e436-42fb-a861-49e4e2644859}" file="" northMode="0" background="true" excludeFromExports="0" resizeMode="0" svgBorderColor="0,0,0,255" opacity="1" svgFillColor="255,255,255,255" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="3.8525,2.584,mm" groupUuid="" id="title_logo_two" outlineWidthM="0.3,mm" mode="0" referencePoint="0" size="22.4124,21.0539,mm" pictureRotation="0" mapUuid="">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option name="active" type="bool" value="true"/>
-       <Option name="expression" type="QString" value="@cplus_setting_cplus_logo"/>
-       <Option name="type" type="int" value="3"/>
+       <Option value="true" name="active" type="bool"/>
+       <Option value="@cplus_setting_cplus_logo" name="expression" type="QString"/>
+       <Option value="3" name="type" type="int"/>
       </Option>
      </Option>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1641,264 +1641,264 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="53" size="176.922,12.3486,mm" referencePoint="0" id="heading_one_level_one_page_two" templateUuid="{035c1525-076a-4568-8872-42fe629bd19b}" positionOnPage="28.5781,2.584,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="CPLUS Analysis Report&#xa;" position="28.5781,309.584,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{035c1525-076a-4568-8872-42fe629bd19b}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="CPLUS Analysis Report&#xa;" uuid="{f736abad-89b6-49bb-9717-96c015a84b96}" positionLock="false" itemRotation="0" valign="32" position="28.5781,309.584,mm" htmlState="0" halign="1" zValue="53" templateUuid="{f736abad-89b6-49bb-9717-96c015a84b96}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="28.5781,2.584,mm" groupUuid="" id="heading_one_level_one_page_two" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="176.922,12.3486,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="28" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="28" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="angle" type="QString" value="0"/>
-       <Option name="cap_style" type="QString" value="square"/>
-       <Option name="color" type="QString" value="213,180,60,255"/>
-       <Option name="horizontal_anchor_point" type="QString" value="1"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="name" type="QString" value="circle"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="35,35,35,255"/>
-       <Option name="outline_style" type="QString" value="solid"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="scale_method" type="QString" value="diameter"/>
-       <Option name="size" type="QString" value="2"/>
-       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="size_unit" type="QString" value="MM"/>
-       <Option name="vertical_anchor_point" type="QString" value="1"/>
+       <Option value="0" name="angle" type="QString"/>
+       <Option value="square" name="cap_style" type="QString"/>
+       <Option value="213,180,60,255" name="color" type="QString"/>
+       <Option value="1" name="horizontal_anchor_point" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="circle" name="name" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="35,35,35,255" name="outline_color" type="QString"/>
+       <Option value="solid" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="diameter" name="scale_method" type="QString"/>
+       <Option value="2" name="size" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+       <Option value="MM" name="size_unit" type="QString"/>
+       <Option value="1" name="vertical_anchor_point" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="52" size="177.161,7.18097,mm" referencePoint="0" id="heading_two_level_two_page_two" templateUuid="{8adab953-08eb-44aa-b93e-8564439156da}" positionOnPage="29.0377,16.457,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_model_scenario_name + ': Implementation Models'%]" position="29.0377,323.457,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{8adab953-08eb-44aa-b93e-8564439156da}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="[% @cplus_model_scenario_name + ': Implementation Models'%]" uuid="{6e58224b-ccc4-45bc-9b51-2e96ecc338c8}" positionLock="false" itemRotation="0" valign="32" position="29.0377,323.457,mm" htmlState="0" halign="1" zValue="52" templateUuid="{6e58224b-ccc4-45bc-9b51-2e96ecc338c8}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="29.0377,16.457,mm" groupUuid="" id="heading_two_level_two_page_two" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="177.161,7.18097,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="18" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="18" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="angle" type="QString" value="0"/>
-       <Option name="cap_style" type="QString" value="square"/>
-       <Option name="color" type="QString" value="213,180,60,255"/>
-       <Option name="horizontal_anchor_point" type="QString" value="1"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="name" type="QString" value="circle"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="35,35,35,255"/>
-       <Option name="outline_style" type="QString" value="solid"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="scale_method" type="QString" value="diameter"/>
-       <Option name="size" type="QString" value="2"/>
-       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="size_unit" type="QString" value="MM"/>
-       <Option name="vertical_anchor_point" type="QString" value="1"/>
+       <Option value="0" name="angle" type="QString"/>
+       <Option value="square" name="cap_style" type="QString"/>
+       <Option value="213,180,60,255" name="color" type="QString"/>
+       <Option value="1" name="horizontal_anchor_point" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="circle" name="name" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="35,35,35,255" name="outline_color" type="QString"/>
+       <Option value="solid" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="diameter" name="scale_method" type="QString"/>
+       <Option value="2" name="size" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+       <Option value="MM" name="size_unit" type="QString"/>
+       <Option value="1" name="vertical_anchor_point" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="51" cornerRadiusMeasure="0,mm" size="210,25.8685,mm" shapeType="1" referencePoint="0" id="heading_background_one_page_two" templateUuid="{da27c9df-6996-4e3c-9119-519154d64646}" positionOnPage="-1.42109e-14,0,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-1.42109e-14,307,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{da27c9df-6996-4e3c-9119-519154d64646}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{7743b924-74a5-424b-a0e1-6b7d31054d24}" positionLock="false" shapeType="1" itemRotation="0" position="-1.42109e-14,307,mm" zValue="51" templateUuid="{7743b924-74a5-424b-a0e1-6b7d31054d24}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="-1.42109e-14,0,mm" groupUuid="" id="heading_background_one_page_two" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210,25.8685,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="3,109,0,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="3,109,0,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="29" size="60.4861,42.7435,mm" sectionHeight="42.7435" referencePoint="4" id="implementation_model_area_table" templateUuid="{23315901-e601-4914-a17b-da0615c317ad}" positionOnPage="52.9039,245.858,mm" background="false" frameJoinStyle="miter" type="65647" sectionX="0" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" multiFrame="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" position="52.9039,245.858,mm" visibility="1" itemRotation="0" sectionY="0" positionLock="false" uuid="{23315901-e601-4914-a17b-da0615c317ad}" multiFrameTemplateUuid="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" hidePageIfEmpty="0" opacity="1" sectionWidth="60.4861" hideBackgroundIfEmpty="0" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem sectionX="0" type="65647" blendMode="0" multiFrameTemplateUuid="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" uuid="{2bc162ff-6d81-4eb0-a418-64318e63eb0a}" positionLock="false" itemRotation="0" sectionHeight="42.7435" multiFrame="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" position="52.9039,245.858,mm" hideBackgroundIfEmpty="0" zValue="29" templateUuid="{2bc162ff-6d81-4eb0-a418-64318e63eb0a}" sectionY="0" background="false" excludeFromExports="0" opacity="1" sectionWidth="60.4861" frame="false" frameJoinStyle="miter" hidePageIfEmpty="0" visibility="1" positionOnPage="52.9039,245.858,mm" groupUuid="" id="implementation_model_area_table" outlineWidthM="0.3,mm" referencePoint="4" size="60.4861,42.7435,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1906,68 +1906,68 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="27" cornerRadiusMeasure="0,mm" size="210.014,248.479,mm" shapeType="1" referencePoint="0" id="CPLUS Map Repeat Area 1" templateUuid="{7c2a6a3b-4d10-41bc-a8f1-a82b22184441}" positionOnPage="9.8431e-17,25.868,mm" background="false" frameJoinStyle="miter" type="78000" groupUuid="" blendMode="0" outlineWidthM="0.4,mm" modelComponentType="unknown" position="9.8431e-17,332.868,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{7c2a6a3b-4d10-41bc-a8f1-a82b22184441}" opacity="1" frame="true" excludeFromExports="0">
-  <FrameColor red="132" green="192" blue="68" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="78000" blendMode="0" modelComponentType="unknown" uuid="{b651e8b4-4ad4-4506-953a-4f78bbd50f94}" positionLock="false" shapeType="1" itemRotation="0" position="9.8431e-17,332.868,mm" zValue="27" templateUuid="{b651e8b4-4ad4-4506-953a-4f78bbd50f94}" background="false" excludeFromExports="0" opacity="1" frame="true" frameJoinStyle="miter" visibility="1" positionOnPage="9.8431e-17,25.868,mm" groupUuid="" id="CPLUS Map Repeat Area 1" outlineWidthM="0.4,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210.014,248.479,mm">
+  <FrameColor red="132" alpha="255" green="192" blue="68"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{2c0fd8a0-902f-4ee3-8782-ecc9cc4f313f}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{2c0fd8a0-902f-4ee3-8782-ecc9cc4f313f}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="229,182,54,0"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="132,192,68,255"/>
-     <Option name="outline_style" type="QString" value="dash"/>
-     <Option name="outline_width" type="QString" value="0"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="229,182,54,0" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="132,192,68,255" name="outline_color" type="QString"/>
+     <Option value="dash" name="outline_style" type="QString"/>
+     <Option value="0" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem zValue="5" size="37.1491,14.1884,mm" referencePoint="0" resizeMode="0" id="logo_3" svgFillColor="255,255,255,255" templateUuid="{982bf0f3-407c-4126-a014-0d345a7427c4}" mode="0" positionOnPage="171.386,277.998,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="34.0522" svgBorderWidth="0.2" mapUuid="" position="171.386,584.998,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{982bf0f3-407c-4126-a014-0d345a7427c4}" pictureHeight="14.1884" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65640" blendMode="0" uuid="{681f446d-9e08-4805-9a04-a16cd3456628}" anchorPoint="0" positionLock="false" pictureWidth="34.0522" svgBorderWidth="0.2" itemRotation="0" pictureHeight="14.1884" position="171.386,584.998,mm" northOffset="0" zValue="5" templateUuid="{681f446d-9e08-4805-9a04-a16cd3456628}" file="" northMode="0" background="false" excludeFromExports="0" resizeMode="0" svgBorderColor="0,0,0,255" opacity="1" svgFillColor="255,255,255,255" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="171.386,277.998,mm" groupUuid="" id="logo_3" outlineWidthM="0.3,mm" mode="0" referencePoint="0" size="37.1491,14.1884,mm" pictureRotation="0" mapUuid="">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option name="active" type="bool" value="true"/>
-       <Option name="expression" type="QString" value="@cplus_setting_ci_logo"/>
-       <Option name="type" type="int" value="3"/>
+       <Option value="true" name="active" type="bool"/>
+       <Option value="@cplus_setting_ci_logo" name="expression" type="QString"/>
+       <Option value="3" name="type" type="int"/>
       </Option>
      </Option>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1975,185 +1975,185 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem zValue="3" size="167.683,15.4824,mm" referencePoint="0" id="accreditation_text_two" templateUuid="{07d7eebf-8352-4a65-9489-3f28a8fdefea}" positionOnPage="2.76111,277.998,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="The boundaries, names, and designations used in this report do [% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" position="2.76111,584.998,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{07d7eebf-8352-4a65-9489-3f28a8fdefea}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="The boundaries, names, and designations used in this report do [% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" uuid="{f638cc48-6d3c-4f67-a56a-3c1c8d8cb2f6}" positionLock="false" itemRotation="0" valign="32" position="2.76111,584.998,mm" htmlState="0" halign="1" zValue="3" templateUuid="{f638cc48-6d3c-4f67-a56a-3c1c8d8cb2f6}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="2.76111,277.998,mm" groupUuid="" id="accreditation_text_two" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="167.683,15.4824,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="7.5" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="7.5" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="2" size="3.62469,4.75988,mm" referencePoint="0" id="page_number_two" templateUuid="{3bb70abe-780a-4fda-bb7a-7e5644491ab9}" positionOnPage="104.818,291.1,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @layout_page %]" position="104.818,598.1,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{3bb70abe-780a-4fda-bb7a-7e5644491ab9}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65641" blendMode="0" marginX="0" labelText="[% @layout_page %]" uuid="{f3312a37-bf8e-4981-b2e0-17e751d17a8f}" positionLock="false" itemRotation="0" valign="32" position="104.818,598.1,mm" htmlState="0" halign="1" zValue="2" templateUuid="{f3312a37-bf8e-4981-b2e0-17e751d17a8f}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="104.818,291.1,mm" groupUuid="" id="page_number_two" outlineWidthM="0.3,mm" referencePoint="0" marginY="0" size="3.62469,4.75988,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+  <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="255,255,255,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="12" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
    <families/>
-   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+   <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+   <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+   <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+    <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
      <data_defined_properties>
       <Option type="Map">
-       <Option name="name" type="QString" value=""/>
+       <Option value="" name="name" type="QString"/>
        <Option name="properties"/>
-       <Option name="type" type="QString" value="collection"/>
+       <Option value="collection" name="type" type="QString"/>
       </Option>
      </data_defined_properties>
-     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+     <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
       <Option type="Map">
-       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="color" type="QString" value="255,255,255,255"/>
-       <Option name="joinstyle" type="QString" value="bevel"/>
-       <Option name="offset" type="QString" value="0,0"/>
-       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-       <Option name="offset_unit" type="QString" value="MM"/>
-       <Option name="outline_color" type="QString" value="128,128,128,255"/>
-       <Option name="outline_style" type="QString" value="no"/>
-       <Option name="outline_width" type="QString" value="0"/>
-       <Option name="outline_width_unit" type="QString" value="MM"/>
-       <Option name="style" type="QString" value="solid"/>
+       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+       <Option value="255,255,255,255" name="color" type="QString"/>
+       <Option value="bevel" name="joinstyle" type="QString"/>
+       <Option value="0,0" name="offset" type="QString"/>
+       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+       <Option value="MM" name="offset_unit" type="QString"/>
+       <Option value="128,128,128,255" name="outline_color" type="QString"/>
+       <Option value="no" name="outline_style" type="QString"/>
+       <Option value="0" name="outline_width" type="QString"/>
+       <Option value="MM" name="outline_width_unit" type="QString"/>
+       <Option value="solid" name="style" type="QString"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+   <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
    <dd_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem zValue="1" cornerRadiusMeasure="0,mm" size="210.362,22.6535,mm" shapeType="1" referencePoint="0" id="footer_background_two" templateUuid="{cc8328b8-6fda-4bb0-82a1-633c7c7d2fa2}" positionOnPage="-0.36335,274.347,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-0.36335,581.347,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{cc8328b8-6fda-4bb0-82a1-633c7c7d2fa2}" opacity="1" frame="false" excludeFromExports="0">
-  <FrameColor red="0" green="0" blue="0" alpha="255"/>
-  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+ <LayoutItem type="65643" blendMode="0" uuid="{8cfff90a-5e3b-4517-bb53-45f432daeb1e}" positionLock="false" shapeType="1" itemRotation="0" position="-0.36335,581.347,mm" zValue="1" templateUuid="{8cfff90a-5e3b-4517-bb53-45f432daeb1e}" background="false" excludeFromExports="0" opacity="1" frame="false" frameJoinStyle="miter" visibility="1" positionOnPage="-0.36335,274.347,mm" groupUuid="" id="footer_background_two" outlineWidthM="0.3,mm" referencePoint="0" cornerRadiusMeasure="0,mm" size="210.362,22.6535,mm">
+  <FrameColor red="0" alpha="255" green="0" blue="0"/>
+  <BackgroundColor red="255" alpha="255" green="255" blue="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+  <symbol alpha="1" clip_to_extent="1" name="" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
    <data_defined_properties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </data_defined_properties>
-   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
+   <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
     <Option type="Map">
-     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="color" type="QString" value="3,109,0,255"/>
-     <Option name="joinstyle" type="QString" value="miter"/>
-     <Option name="offset" type="QString" value="0,0"/>
-     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-     <Option name="offset_unit" type="QString" value="MM"/>
-     <Option name="outline_color" type="QString" value="0,0,0,255"/>
-     <Option name="outline_style" type="QString" value="no"/>
-     <Option name="outline_width" type="QString" value="0.3"/>
-     <Option name="outline_width_unit" type="QString" value="MM"/>
-     <Option name="style" type="QString" value="solid"/>
+     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+     <Option value="3,109,0,255" name="color" type="QString"/>
+     <Option value="miter" name="joinstyle" type="QString"/>
+     <Option value="0,0" name="offset" type="QString"/>
+     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+     <Option value="MM" name="offset_unit" type="QString"/>
+     <Option value="0,0,0,255" name="outline_color" type="QString"/>
+     <Option value="no" name="outline_style" type="QString"/>
+     <Option value="0.3" name="outline_width" type="QString"/>
+     <Option value="MM" name="outline_width_unit" type="QString"/>
+     <Option value="solid" name="style" type="QString"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutMultiFrame headerMode="2" horizontalGrid="1" wrapBehavior="0" resizeMode="0" showGrid="1" templateUuid="{fed81923-0826-48b4-900e-b8160395b5be}" includeHeader="0" gridStrokeWidth="0.1" emptyTableMode="0" type="65652" emptyTableMessage="" cellMargin="0.9" showEmptyRows="0" backgroundColor="255,255,255,255" headerHAlignment="0" verticalGrid="0" gridColor="0,0,0,255" uuid="{fed81923-0826-48b4-900e-b8160395b5be}">
-  <childFrame templateUuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" uuid="{1dae8448-722b-438b-8f7c-0c2078280f67}"/>
+ <LayoutMultiFrame backgroundColor="255,255,255,255" showGrid="1" headerMode="2" emptyTableMessage="" type="65652" includeHeader="0" gridStrokeWidth="0.1" horizontalGrid="1" wrapBehavior="0" uuid="{aa9ae043-cbbc-42f1-931f-9b3e7d223321}" headerHAlignment="0" cellMargin="0.9" templateUuid="{aa9ae043-cbbc-42f1-931f-9b3e7d223321}" gridColor="0,0,0,255" resizeMode="0" verticalGrid="0" showEmptyRows="0" emptyTableMode="0">
+  <childFrame templateUuid="{8e55e54e-d39a-42fd-9a22-944063807fd3}" uuid="{8e55e54e-d39a-42fd-9a22-944063807fd3}"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -2161,146 +2161,146 @@
    </customproperties>
   </LayoutObject>
   <headerTextFormat>
-   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="12" namedStyle="" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
     <families/>
-    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+    <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+    <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+    <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+     <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="color" type="QString" value="255,255,255,255"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="128,128,128,255"/>
-        <Option name="outline_style" type="QString" value="no"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="style" type="QString" value="solid"/>
+        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+        <Option value="255,255,255,255" name="color" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="128,128,128,255" name="outline_color" type="QString"/>
+        <Option value="no" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="solid" name="style" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+    <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
     <dd_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dd_properties>
    </text-style>
   </headerTextFormat>
   <contentTextFormat>
-   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="9" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="9" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
     <families/>
-    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+    <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+    <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+    <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+     <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="angle" type="QString" value="0"/>
-        <Option name="cap_style" type="QString" value="square"/>
-        <Option name="color" type="QString" value="255,158,23,255"/>
-        <Option name="horizontal_anchor_point" type="QString" value="1"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="name" type="QString" value="circle"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="35,35,35,255"/>
-        <Option name="outline_style" type="QString" value="solid"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="scale_method" type="QString" value="diameter"/>
-        <Option name="size" type="QString" value="2"/>
-        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="size_unit" type="QString" value="MM"/>
-        <Option name="vertical_anchor_point" type="QString" value="1"/>
+        <Option value="0" name="angle" type="QString"/>
+        <Option value="square" name="cap_style" type="QString"/>
+        <Option value="255,158,23,255" name="color" type="QString"/>
+        <Option value="1" name="horizontal_anchor_point" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="circle" name="name" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="35,35,35,255" name="outline_color" type="QString"/>
+        <Option value="solid" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="diameter" name="scale_method" type="QString"/>
+        <Option value="2" name="size" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+        <Option value="MM" name="size_unit" type="QString"/>
+        <Option value="1" name="vertical_anchor_point" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="color" type="QString" value="255,255,255,255"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="128,128,128,255"/>
-        <Option name="outline_style" type="QString" value="no"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="style" type="QString" value="solid"/>
+        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+        <Option value="255,255,255,255" name="color" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="128,128,128,255" name="outline_color" type="QString"/>
+        <Option value="no" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="solid" name="style" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+    <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
     <dd_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dd_properties>
    </text-style>
   </contentTextFormat>
   <displayColumns>
-   <column heading="" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <column vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </column>
-   <column heading="" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <column vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </column>
   </displayColumns>
   <sortColumns/>
@@ -2319,146 +2319,146 @@
   <contents>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Biodiversity"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="Biodiversity" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="50%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Livelihoods"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="50%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="50%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Climate Resilience"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="Livelihoods" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="100%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Ecological Infrastructure"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="0%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="50%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Policy"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="Climate Resilience" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="0%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Finance- Years Experience"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="0%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="100%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Finance - Market Trends"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="Ecological Infrastructure" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="0%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Finance - Net Present Value"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
-    </Option>
-    <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="0%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="0%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="Finance - Carbon"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="Policy" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
-     <Option name="content" type="QString" value="75%"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="background" type="color"/>
+     <Option value="0%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="Finance- Years Experience" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="0%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="Finance - Market Trends" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="0%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="Finance - Net Present Value" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="0%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="Finance - Carbon" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
+    </Option>
+    <Option type="Map">
+     <Option value="" name="background" type="color"/>
+     <Option value="75%" name="content" type="QString"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
   </contents>
@@ -2478,14 +2478,14 @@
    <column width="0"/>
   </columnWidths>
  </LayoutMultiFrame>
- <LayoutMultiFrame headerMode="1" horizontalGrid="1" wrapBehavior="0" resizeMode="0" showGrid="1" templateUuid="{c3df8176-117d-485c-abea-d8c2ae834b3a}" includeHeader="1" gridStrokeWidth="0.1" emptyTableMode="0" type="65652" emptyTableMessage="" cellMargin="1" showEmptyRows="0" backgroundColor="255,255,255,255" headerHAlignment="0" verticalGrid="0" gridColor="0,0,0,255" uuid="{c3df8176-117d-485c-abea-d8c2ae834b3a}">
-  <childFrame templateUuid="{23315901-e601-4914-a17b-da0615c317ad}" uuid="{23315901-e601-4914-a17b-da0615c317ad}"/>
+ <LayoutMultiFrame backgroundColor="255,255,255,255" showGrid="1" headerMode="1" emptyTableMessage="" type="65652" includeHeader="1" gridStrokeWidth="0.1" horizontalGrid="1" wrapBehavior="0" uuid="{df352d93-c163-46cb-a524-b08b18e32fc9}" headerHAlignment="0" cellMargin="1" templateUuid="{df352d93-c163-46cb-a524-b08b18e32fc9}" gridColor="0,0,0,255" resizeMode="0" verticalGrid="0" showEmptyRows="0" emptyTableMode="0">
+  <childFrame templateUuid="{2bc162ff-6d81-4eb0-a418-64318e63eb0a}" uuid="{2bc162ff-6d81-4eb0-a418-64318e63eb0a}"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option name="name" type="QString" value=""/>
+     <Option value="" name="name" type="QString"/>
      <Option name="properties"/>
-     <Option name="type" type="QString" value="collection"/>
+     <Option value="collection" name="type" type="QString"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -2493,185 +2493,185 @@
    </customproperties>
   </LayoutObject>
   <headerTextFormat>
-   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="11" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="11" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
     <families/>
-    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+    <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+    <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+    <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+     <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="angle" type="QString" value="0"/>
-        <Option name="cap_style" type="QString" value="square"/>
-        <Option name="color" type="QString" value="164,113,88,255"/>
-        <Option name="horizontal_anchor_point" type="QString" value="1"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="name" type="QString" value="circle"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="35,35,35,255"/>
-        <Option name="outline_style" type="QString" value="solid"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="scale_method" type="QString" value="diameter"/>
-        <Option name="size" type="QString" value="2"/>
-        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="size_unit" type="QString" value="MM"/>
-        <Option name="vertical_anchor_point" type="QString" value="1"/>
+        <Option value="0" name="angle" type="QString"/>
+        <Option value="square" name="cap_style" type="QString"/>
+        <Option value="164,113,88,255" name="color" type="QString"/>
+        <Option value="1" name="horizontal_anchor_point" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="circle" name="name" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="35,35,35,255" name="outline_color" type="QString"/>
+        <Option value="solid" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="diameter" name="scale_method" type="QString"/>
+        <Option value="2" name="size" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+        <Option value="MM" name="size_unit" type="QString"/>
+        <Option value="1" name="vertical_anchor_point" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="color" type="QString" value="255,255,255,255"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="128,128,128,255"/>
-        <Option name="outline_style" type="QString" value="no"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="style" type="QString" value="solid"/>
+        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+        <Option value="255,255,255,255" name="color" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="128,128,128,255" name="outline_color" type="QString"/>
+        <Option value="no" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="solid" name="style" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+    <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
     <dd_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dd_properties>
    </text-style>
   </headerTextFormat>
   <contentTextFormat>
-   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="9" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
+   <text-style multilineHeight="1" fontFamily="Ubuntu" blendMode="0" fontKerning="1" allowHtml="0" fontUnderline="0" textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" fontSize="9" namedStyle="Regular" fontItalic="0" fontLetterSpacing="0" capitalization="0" textOpacity="1" textOrientation="horizontal" multilineHeightUnit="Percentage" previewBkgrdColor="255,255,255,255" fontStrikeout="0" fontWeight="50" fontSizeUnit="Point">
     <families/>
-    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
-    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
-    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
-     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
+    <text-buffer bufferBlendMode="0" bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferNoFill="1" bufferOpacity="1"/>
+    <text-mask maskJoinStyle="128" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0" maskSizeUnits="MM"/>
+    <background shapeSizeUnit="MM" shapeRadiiX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeOffsetY="0" shapeType="0" shapeOpacity="1" shapeBlendMode="0" shapeJoinStyle="64" shapeRotation="0" shapeSizeX="0" shapeBorderColor="128,128,128,255" shapeFillColor="255,255,255,255" shapeBorderWidth="0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeSVGFile="" shapeRadiiY="0" shapeOffsetX="0" shapeSizeY="0" shapeDraw="0">
+     <symbol alpha="1" clip_to_extent="1" name="markerSymbol" frame_rate="10" force_rhr="0" type="marker" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="angle" type="QString" value="0"/>
-        <Option name="cap_style" type="QString" value="square"/>
-        <Option name="color" type="QString" value="133,182,111,255"/>
-        <Option name="horizontal_anchor_point" type="QString" value="1"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="name" type="QString" value="circle"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="35,35,35,255"/>
-        <Option name="outline_style" type="QString" value="solid"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="scale_method" type="QString" value="diameter"/>
-        <Option name="size" type="QString" value="2"/>
-        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="size_unit" type="QString" value="MM"/>
-        <Option name="vertical_anchor_point" type="QString" value="1"/>
+        <Option value="0" name="angle" type="QString"/>
+        <Option value="square" name="cap_style" type="QString"/>
+        <Option value="133,182,111,255" name="color" type="QString"/>
+        <Option value="1" name="horizontal_anchor_point" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="circle" name="name" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="35,35,35,255" name="outline_color" type="QString"/>
+        <Option value="solid" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="diameter" name="scale_method" type="QString"/>
+        <Option value="2" name="size" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+        <Option value="MM" name="size_unit" type="QString"/>
+        <Option value="1" name="vertical_anchor_point" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+     <symbol alpha="1" clip_to_extent="1" name="fillSymbol" frame_rate="10" force_rhr="0" type="fill" is_animated="0">
       <data_defined_properties>
        <Option type="Map">
-        <Option name="name" type="QString" value=""/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
+        <Option value="collection" name="type" type="QString"/>
        </Option>
       </data_defined_properties>
-      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+      <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
        <Option type="Map">
-        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="color" type="QString" value="255,255,255,255"/>
-        <Option name="joinstyle" type="QString" value="bevel"/>
-        <Option name="offset" type="QString" value="0,0"/>
-        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-        <Option name="offset_unit" type="QString" value="MM"/>
-        <Option name="outline_color" type="QString" value="128,128,128,255"/>
-        <Option name="outline_style" type="QString" value="no"/>
-        <Option name="outline_width" type="QString" value="0"/>
-        <Option name="outline_width_unit" type="QString" value="MM"/>
-        <Option name="style" type="QString" value="solid"/>
+        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+        <Option value="255,255,255,255" name="color" type="QString"/>
+        <Option value="bevel" name="joinstyle" type="QString"/>
+        <Option value="0,0" name="offset" type="QString"/>
+        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+        <Option value="MM" name="offset_unit" type="QString"/>
+        <Option value="128,128,128,255" name="outline_color" type="QString"/>
+        <Option value="no" name="outline_style" type="QString"/>
+        <Option value="0" name="outline_width" type="QString"/>
+        <Option value="MM" name="outline_width_unit" type="QString"/>
+        <Option value="solid" name="style" type="QString"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option name="name" type="QString" value=""/>
+         <Option value="" name="name" type="QString"/>
          <Option name="properties"/>
-         <Option name="type" type="QString" value="collection"/>
+         <Option value="collection" name="type" type="QString"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
+    <shadow shadowOffsetGlobal="1" shadowRadius="1.5" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowUnder="0" shadowOffsetAngle="135" shadowOffsetDist="1" shadowOffsetUnit="MM" shadowDraw="0" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowBlendMode="6" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
     <dd_properties>
      <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option value="collection" name="type" type="QString"/>
      </Option>
     </dd_properties>
    </text-style>
   </contentTextFormat>
   <displayColumns>
-   <column heading="Implementation Model" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <column vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="Implementation Model">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </column>
-   <column heading="Area (ha)" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <column vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="Area (ha)">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </column>
   </displayColumns>
   <sortColumns/>
@@ -2687,28 +2687,28 @@
    <lastRow enabled="0" cellBackgroundColor="255,255,255,255"/>
   </cellStyles>
   <headers>
-   <header heading="Implementation Model" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <header vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="Implementation Model">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </header>
-   <header heading="Area (ha)" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
-    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
+   <header vAlignment="128" sortOrder="0" width="0" hAlignment="1" sortByRank="0" attribute="" heading="Area (ha)">
+    <backgroundColor red="0" alpha="0" green="0" blue="0"/>
    </header>
   </headers>
   <contents>
    <row>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
+     <Option value="" name="background" type="color"/>
      <Option name="content" type="invalid"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
     <Option type="Map">
-     <Option name="background" type="color" value=""/>
+     <Option value="" name="background" type="color"/>
      <Option name="content" type="invalid"/>
-     <Option name="foreground" type="color" value=""/>
-     <Option name="halign" type="int" value="1"/>
-     <Option name="valign" type="int" value="128"/>
+     <Option value="" name="foreground" type="color"/>
+     <Option value="1" name="halign" type="int"/>
+     <Option value="128" name="valign" type="int"/>
     </Option>
    </row>
   </contents>
@@ -2722,48 +2722,48 @@
  </LayoutMultiFrame>
  <customproperties>
   <Option type="Map">
-   <Option name="atlasRasterFormat" type="QString" value="png"/>
-   <Option name="forceVector" type="int" value="0"/>
-   <Option name="pdfAppendGeoreference" type="int" value="1"/>
-   <Option name="pdfCreateGeoPdf" type="int" value="0"/>
-   <Option name="pdfDisableRasterTiles" type="int" value="0"/>
-   <Option name="pdfExportThemes" type="QString" value=""/>
-   <Option name="pdfIncludeMetadata" type="int" value="1"/>
-   <Option name="pdfLayerOrder" type="QString" value="Final_Highest_Position_Carbon_0e7be90c_db93_4b7b_b9be_c11aa38ab4c1~~~social_int_clip_norm_inverse_e2de5f1a_aa21_4c94_aa2d_6196dac6aff0~~~social_int_clip_norm_a4374b7b_741d_4270_9e2b_d27320de59c4~~~Policy_b44fa87c_4711_4dde_b139_3d8e91767ddc~~~ei_all_gknp_clip_norm_inverse_ca6afb6d_ec6b_441b_a751_3dd0fdaff13d~~~ei_all_gknp_clip_norm_2310282e_df57_4cb2_999f_25c2751a08d5~~~cccombo_clip_norm_inverse_3d4977d0_97c3_44f1_b8bc_3fb62eda96ec~~~cccombo_clip_norm_3b275553_b29f_4f39_941f_ee136d826c05~~~biocombine_clip_norm_inverse_fc876422_7ac0_40ff_a094_ff41c51cb918~~~biocombine_clip_norm_d7722cb5_4adf_4f3a_86b5_72c4790eeca6~~~Final_Alien_Plant_Removal_f4d0b80b_e589_4422_8a02_4cc1b7b0f0c0~~~Final_Assisted_Nat_Regen_556819d3_06df_4d63_bf11_1b4fff3c0b2d~~~Final_Bush_Thinning_d5284c1f_c2eb_4c52_bd0f_27eb60319e59~~~Final_Eat_Fresh_1d7180a9_5c09_4c95_8a51_9bd29b569e98~~~Final_Herding_4_Health_e329e016_667c_410f_99b4_36a37226904f~~~Final_Wattle_Naturally_d729d8a8_0a0e_49d4_8d20_33165713cb23~~~Woody_Encroachment_norm_6da710af_b9a3_48f5_ac08_634f30d21ab3~~~Restoration_Wetland_carbon_norm_5cbc6509_5c6b_4fec_ad84_7e4c408a1faf~~~Restoration_Savanna_carbon_norm_6f983163_023e_4233_902a_819e327f7321~~~Restoration_Forest_carbon_norm_f1d45658_f78c_4b3c_96b6_8f1052314846~~~Fire_Management_Krugerhalf_carbon_norm_895ba558_c8d2_40db_8a10_7a1781c6a5d0~~~Avoided_Wetland_carbon_norm_b1ffda03_6692_4e6c_87d4_5a881732f0e1~~~Avoided_OpenWoodland_NaturalWoodedLand_carbon_norm_2efdcdd6_eebf_46bd_a30f_01de841c105c~~~Avoided_Grassland_carbon_norm_246e0f70_8465_4c60_aaae_7786e19dab54~~~Avoided_Forest_carbon_norm_46c2da65_20a7_4bce_8681_d219ec782fcf~~~Animal_Management_carbon_norm_21d7d1ea_f528_4a50_9a4e_af40e33fd8d7~~~Agroforestry_carbon_norm_f5034c21_96ef_446b_99e4_7443f34ff419"/>
-   <Option name="pdfLosslessImages" type="int" value="0"/>
-   <Option name="pdfOgcBestPracticeFormat" type="int" value="0"/>
-   <Option name="pdfSimplify" type="int" value="1"/>
-   <Option name="pdfTextFormat" type="int" value="0"/>
-   <Option name="singleFile" type="bool" value="true"/>
+   <Option value="png" name="atlasRasterFormat" type="QString"/>
+   <Option value="0" name="forceVector" type="int"/>
+   <Option value="1" name="pdfAppendGeoreference" type="int"/>
+   <Option value="0" name="pdfCreateGeoPdf" type="int"/>
+   <Option value="0" name="pdfDisableRasterTiles" type="int"/>
+   <Option value="" name="pdfExportThemes" type="QString"/>
+   <Option value="1" name="pdfIncludeMetadata" type="int"/>
+   <Option value="Final_Highest_Position_Carbon_0e7be90c_db93_4b7b_b9be_c11aa38ab4c1~~~social_int_clip_norm_inverse_e2de5f1a_aa21_4c94_aa2d_6196dac6aff0~~~social_int_clip_norm_a4374b7b_741d_4270_9e2b_d27320de59c4~~~Policy_b44fa87c_4711_4dde_b139_3d8e91767ddc~~~ei_all_gknp_clip_norm_inverse_ca6afb6d_ec6b_441b_a751_3dd0fdaff13d~~~ei_all_gknp_clip_norm_2310282e_df57_4cb2_999f_25c2751a08d5~~~cccombo_clip_norm_inverse_3d4977d0_97c3_44f1_b8bc_3fb62eda96ec~~~cccombo_clip_norm_3b275553_b29f_4f39_941f_ee136d826c05~~~biocombine_clip_norm_inverse_fc876422_7ac0_40ff_a094_ff41c51cb918~~~biocombine_clip_norm_d7722cb5_4adf_4f3a_86b5_72c4790eeca6~~~Final_Alien_Plant_Removal_f4d0b80b_e589_4422_8a02_4cc1b7b0f0c0~~~Final_Assisted_Nat_Regen_556819d3_06df_4d63_bf11_1b4fff3c0b2d~~~Final_Bush_Thinning_d5284c1f_c2eb_4c52_bd0f_27eb60319e59~~~Final_Eat_Fresh_1d7180a9_5c09_4c95_8a51_9bd29b569e98~~~Final_Herding_4_Health_e329e016_667c_410f_99b4_36a37226904f~~~Final_Wattle_Naturally_d729d8a8_0a0e_49d4_8d20_33165713cb23~~~Woody_Encroachment_norm_6da710af_b9a3_48f5_ac08_634f30d21ab3~~~Restoration_Wetland_carbon_norm_5cbc6509_5c6b_4fec_ad84_7e4c408a1faf~~~Restoration_Savanna_carbon_norm_6f983163_023e_4233_902a_819e327f7321~~~Restoration_Forest_carbon_norm_f1d45658_f78c_4b3c_96b6_8f1052314846~~~Fire_Management_Krugerhalf_carbon_norm_895ba558_c8d2_40db_8a10_7a1781c6a5d0~~~Avoided_Wetland_carbon_norm_b1ffda03_6692_4e6c_87d4_5a881732f0e1~~~Avoided_OpenWoodland_NaturalWoodedLand_carbon_norm_2efdcdd6_eebf_46bd_a30f_01de841c105c~~~Avoided_Grassland_carbon_norm_246e0f70_8465_4c60_aaae_7786e19dab54~~~Avoided_Forest_carbon_norm_46c2da65_20a7_4bce_8681_d219ec782fcf~~~Animal_Management_carbon_norm_21d7d1ea_f528_4a50_9a4e_af40e33fd8d7~~~Agroforestry_carbon_norm_f5034c21_96ef_446b_99e4_7443f34ff419" name="pdfLayerOrder" type="QString"/>
+   <Option value="0" name="pdfLosslessImages" type="int"/>
+   <Option value="0" name="pdfOgcBestPracticeFormat" type="int"/>
+   <Option value="1" name="pdfSimplify" type="int"/>
+   <Option value="0" name="pdfTextFormat" type="int"/>
+   <Option value="true" name="singleFile" type="bool"/>
    <Option name="variableNames" type="List">
-    <Option type="QString" value="cplus_setting_organization"/>
-    <Option type="QString" value="cplus_setting_email"/>
-    <Option type="QString" value="cplus_setting_website"/>
-    <Option type="QString" value="cplus_setting_custom_logo"/>
-    <Option type="QString" value="cplus_setting_cplus_logo"/>
-    <Option type="QString" value="cplus_setting_ci_logo"/>
-    <Option type="QString" value="cplus_setting_footer"/>
-    <Option type="QString" value="cplus_setting_disclaimer"/>
-    <Option type="QString" value="cplus_setting_license"/>
-    <Option type="QString" value="cplus_setting_base_dir"/>
-    <Option type="QString" value="cplus_model_scenario_name"/>
-    <Option type="QString" value="cplus_model_scenario_description"/>
+    <Option value="cplus_setting_organization" type="QString"/>
+    <Option value="cplus_setting_email" type="QString"/>
+    <Option value="cplus_setting_website" type="QString"/>
+    <Option value="cplus_setting_custom_logo" type="QString"/>
+    <Option value="cplus_setting_cplus_logo" type="QString"/>
+    <Option value="cplus_setting_ci_logo" type="QString"/>
+    <Option value="cplus_setting_footer" type="QString"/>
+    <Option value="cplus_setting_disclaimer" type="QString"/>
+    <Option value="cplus_setting_license" type="QString"/>
+    <Option value="cplus_setting_base_dir" type="QString"/>
+    <Option value="cplus_model_scenario_name" type="QString"/>
+    <Option value="cplus_model_scenario_description" type="QString"/>
    </Option>
    <Option name="variableValues" type="List">
-    <Option type="QString" value=""/>
-    <Option type="QString" value=""/>
-    <Option type="QString" value=""/>
-    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin/logos/ci_logo.png"/>
-    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\cplus_logo.svg"/>
-    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\ci_logo.svg"/>
-    <Option type="QString" value=""/>
-    <Option type="QString" value="The boundaries, names, and designations used in this report do not imply official endorsement or acceptance by Conservation International Foundation, or its partner organizations and contributors."/>
-    <Option type="QString" value="Creative Commons Attribution 4.0 International License (CC BY 4.0)"/>
-    <Option type="QString" value="D:\Frank\Kartoza\Data\cplus\Temp"/>
-    <Option type="QString" value="Scenario name will be inserted here"/>
-    <Option type="QString" value="Scenario description will be inserted here"/>
+    <Option value="" type="QString"/>
+    <Option value="" type="QString"/>
+    <Option value="" type="QString"/>
+    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin/logos/ci_logo.png" type="QString"/>
+    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\cplus_logo.svg" type="QString"/>
+    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\ci_logo.svg" type="QString"/>
+    <Option value="" type="QString"/>
+    <Option value="The boundaries, names, and designations used in this report do not imply official endorsement or acceptance by Conservation International Foundation, or its partner organizations and contributors." type="QString"/>
+    <Option value="Creative Commons Attribution 4.0 International License (CC BY 4.0)" type="QString"/>
+    <Option value="D:\Frank\Kartoza\Data\cplus\Temp" type="QString"/>
+    <Option value="Scenario name will be inserted here" type="QString"/>
+    <Option value="Scenario description will be inserted here" type="QString"/>
    </Option>
   </Option>
  </customproperties>
- <Atlas hideCoverage="0" filterFeatures="0" filenamePattern="'output_'||@atlas_featurenumber" enabled="0" coverageLayer="" sortFeatures="0" pageNameExpression="&quot;NAME&quot;"/>
+ <Atlas filterFeatures="0" sortFeatures="0" hideCoverage="0" filenamePattern="'output_'||@atlas_featurenumber" pageNameExpression="&quot;NAME&quot;" enabled="0" coverageLayer=""/>
 </Layout>

--- a/src/cplus_plugin/app_data/reports/main.qpt
+++ b/src/cplus_plugin/app_data/reports/main.qpt
@@ -1,146 +1,146 @@
-<Layout worldFileMap="{a7f6c8ef-3f0d-4400-b0ce-596a2c03d638}" name="CPLUS Report" units="mm" printResolution="300">
- <Snapper snapToGuides="1" snapToGrid="0" snapToItems="1" tolerance="5"/>
- <Grid resUnits="mm" offsetX="0" resolution="10" offsetY="0" offsetUnits="mm"/>
+<Layout name="CPLUS Report" worldFileMap="{a7f6c8ef-3f0d-4400-b0ce-596a2c03d638}" units="mm" printResolution="300">
+ <Snapper snapToItems="1" snapToGrid="0" tolerance="5" snapToGuides="1"/>
+ <Grid resolution="10" offsetUnits="mm" resUnits="mm" offsetY="0" offsetX="0"/>
  <PageCollection>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{c5f1dd4d-79e9-4806-a29f-1485f3f344bb}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{c5f1dd4d-79e9-4806-a29f-1485f3f344bb}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="255,255,255,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="35,35,35,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.26" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="255,255,255,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="35,35,35,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.26"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
-  <LayoutItem type="65638" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" zValue="0" excludeFromExports="0" background="true" outlineWidthM="0.3,mm" positionLock="false" id="" frame="false" opacity="1" size="210,297,mm" positionOnPage="0,0,mm" uuid="{09e87098-99ce-4356-8f85-fefe77ee9bb4}" position="0,0,mm" templateUuid="{09e87098-99ce-4356-8f85-fefe77ee9bb4}" itemRotation="0" groupUuid="">
-   <FrameColor alpha="255" red="0" green="0" blue="0"/>
-   <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+  <LayoutItem zValue="0" size="210,297,mm" referencePoint="0" id="" templateUuid="{231d5976-7eb4-4349-8b02-ee322d29c36a}" positionOnPage="0,0,mm" background="true" frameJoinStyle="miter" type="65638" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,0,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{231d5976-7eb4-4349-8b02-ee322d29c36a}" opacity="1" frame="false" excludeFromExports="0">
+   <FrameColor red="0" green="0" blue="0" alpha="255"/>
+   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
    <LayoutObject>
     <dataDefinedProperties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dataDefinedProperties>
     <customproperties>
      <Option/>
     </customproperties>
    </LayoutObject>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{0b8f9fab-be9d-4b2d-8c5f-06bf99b656cb}">
+    <layer class="SimpleFill" pass="0" enabled="1" id="{0b8f9fab-be9d-4b2d-8c5f-06bf99b656cb}" locked="0">
      <Option type="Map">
-      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-      <Option value="255,255,255,255" name="color" type="QString"/>
-      <Option value="miter" name="joinstyle" type="QString"/>
-      <Option value="0,0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="35,35,35,255" name="outline_color" type="QString"/>
-      <Option value="no" name="outline_style" type="QString"/>
-      <Option value="0.26" name="outline_width" type="QString"/>
-      <Option value="MM" name="outline_width_unit" type="QString"/>
-      <Option value="solid" name="style" type="QString"/>
+      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="color" type="QString" value="255,255,255,255"/>
+      <Option name="joinstyle" type="QString" value="miter"/>
+      <Option name="offset" type="QString" value="0,0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="outline_color" type="QString" value="35,35,35,255"/>
+      <Option name="outline_style" type="QString" value="no"/>
+      <Option name="outline_width" type="QString" value="0.26"/>
+      <Option name="outline_width_unit" type="QString" value="MM"/>
+      <Option name="style" type="QString" value="solid"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </LayoutItem>
-  <LayoutItem type="65638" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" zValue="0" excludeFromExports="0" background="true" outlineWidthM="0.3,mm" positionLock="false" id="" frame="false" opacity="1" size="210,297,mm" positionOnPage="0,0,mm" uuid="{b82cea15-6514-4e6d-baa6-5d17b89702fe}" position="0,307,mm" templateUuid="{b82cea15-6514-4e6d-baa6-5d17b89702fe}" itemRotation="0" groupUuid="">
-   <FrameColor alpha="255" red="0" green="0" blue="0"/>
-   <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+  <LayoutItem zValue="0" size="210,297,mm" referencePoint="0" id="" templateUuid="{0f29ecee-a2e6-4a01-b458-00761bc1bdd8}" positionOnPage="0,0,mm" background="true" frameJoinStyle="miter" type="65638" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,307,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{0f29ecee-a2e6-4a01-b458-00761bc1bdd8}" opacity="1" frame="false" excludeFromExports="0">
+   <FrameColor red="0" green="0" blue="0" alpha="255"/>
+   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
    <LayoutObject>
     <dataDefinedProperties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dataDefinedProperties>
     <customproperties>
      <Option/>
     </customproperties>
    </LayoutObject>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{fa834403-7cda-4451-8ee9-9ce2d44816e3}">
+    <layer class="SimpleFill" pass="0" enabled="1" id="{fa834403-7cda-4451-8ee9-9ce2d44816e3}" locked="0">
      <Option type="Map">
-      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-      <Option value="255,255,255,255" name="color" type="QString"/>
-      <Option value="miter" name="joinstyle" type="QString"/>
-      <Option value="0,0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="35,35,35,255" name="outline_color" type="QString"/>
-      <Option value="no" name="outline_style" type="QString"/>
-      <Option value="0.26" name="outline_width" type="QString"/>
-      <Option value="MM" name="outline_width_unit" type="QString"/>
-      <Option value="solid" name="style" type="QString"/>
+      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="color" type="QString" value="255,255,255,255"/>
+      <Option name="joinstyle" type="QString" value="miter"/>
+      <Option name="offset" type="QString" value="0,0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="outline_color" type="QString" value="35,35,35,255"/>
+      <Option name="outline_style" type="QString" value="no"/>
+      <Option name="outline_width" type="QString" value="0.26"/>
+      <Option name="outline_width_unit" type="QString" value="MM"/>
+      <Option name="style" type="QString" value="solid"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </LayoutItem>
   <GuideCollection visible="1">
-   <Guide page="0" position="105.79424684213332" orientation="2" units="mm"/>
-   <Guide page="1" position="105.79424684213332" orientation="2" units="mm"/>
+   <Guide page="0" orientation="2" units="mm" position="105.79424684213332"/>
+   <Guide page="1" orientation="2" units="mm" position="105.79424684213332"/>
   </GuideCollection>
  </PageCollection>
- <LayoutItem type="65647" multiFrame="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" sectionY="0" frameJoinStyle="miter" sectionHeight="48.0525" visibility="1" blendMode="0" referencePoint="0" multiFrameTemplateUuid="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" zValue="88" excludeFromExports="0" hideBackgroundIfEmpty="0" background="false" outlineWidthM="0.3,mm" positionLock="false" hidePageIfEmpty="0" id="assigned_weights_table" frame="false" opacity="1" sectionX="0" size="51.1961,48.0525,mm" positionOnPage="105.794,224.486,mm" uuid="{a39f34e3-86ce-4103-966f-d187009a1806}" position="105.794,224.486,mm" templateUuid="{a39f34e3-86ce-4103-966f-d187009a1806}" itemRotation="0" sectionWidth="51.1961" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="88" size="51.1961,48.0525,mm" sectionHeight="48.0525" referencePoint="4" id="assigned_weights_table" templateUuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" positionOnPage="158.054,248.512,mm" background="false" frameJoinStyle="miter" type="65647" sectionX="0" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" multiFrame="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" position="158.054,248.512,mm" visibility="1" itemRotation="0" sectionY="0" positionLock="false" uuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" multiFrameTemplateUuid="{97a6c9b0-747d-4643-a25b-1c9a27b83c04}" hidePageIfEmpty="0" opacity="1" sectionWidth="51.1961" hideBackgroundIfEmpty="0" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -148,21 +148,21 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem type="65640" frameJoinStyle="miter" svgBorderColor="0,0,0,255" visibility="1" blendMode="0" referencePoint="0" svgFillColor="255,255,255,255" pictureWidth="21.0539" zValue="80" excludeFromExports="0" resizeMode="0" mode="0" background="true" anchorPoint="0" outlineWidthM="0.3,mm" svgBorderWidth="0.2" positionLock="false" pictureRotation="0" mapUuid="" id="title_logo_one" frame="false" opacity="1" file="" size="22.4124,21.0539,mm" positionOnPage="3.8525,2.58392,mm" uuid="{06ae2e68-0247-4a7a-9c1f-44c6b6c0b3f2}" position="3.8525,2.58392,mm" templateUuid="{06ae2e68-0247-4a7a-9c1f-44c6b6c0b3f2}" itemRotation="0" pictureHeight="21.0539" northOffset="0" groupUuid="" northMode="0">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="80" size="22.4124,21.0539,mm" referencePoint="0" resizeMode="0" id="title_logo_one" svgFillColor="255,255,255,255" templateUuid="{31715c90-a06e-477e-982d-7d47b2fd8d5f}" mode="0" positionOnPage="3.8525,2.58392,mm" background="true" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="21.0539" svgBorderWidth="0.2" mapUuid="" position="3.8525,2.58392,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{31715c90-a06e-477e-982d-7d47b2fd8d5f}" pictureHeight="21.0539" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option value="true" name="active" type="bool"/>
-       <Option value="@cplus_setting_cplus_logo" name="expression" type="QString"/>
-       <Option value="3" name="type" type="int"/>
+       <Option name="active" type="bool" value="true"/>
+       <Option name="expression" type="QString" value="@cplus_setting_cplus_logo"/>
+       <Option name="type" type="int" value="3"/>
       </Option>
      </Option>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -170,264 +170,264 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem labelText="CPLUS Analysis Report&#xa;" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="79" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="heading_one_level_one_page_one" frame="false" opacity="1" size="176.922,12.3486,mm" positionOnPage="28.5781,2.58392,mm" uuid="{d2a52494-b1d1-45b5-845a-41a559e7f466}" position="28.5781,2.58392,mm" templateUuid="{d2a52494-b1d1-45b5-845a-41a559e7f466}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="79" size="176.922,12.3486,mm" referencePoint="0" id="heading_one_level_one_page_one" templateUuid="{c578549c-c230-473a-8dc5-b3f1dcba3af3}" positionOnPage="28.5781,2.58392,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="CPLUS Analysis Report&#xa;" position="28.5781,2.58392,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{c578549c-c230-473a-8dc5-b3f1dcba3af3}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="28" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="28" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="0" name="angle" type="QString"/>
-       <Option value="square" name="cap_style" type="QString"/>
-       <Option value="213,180,60,255" name="color" type="QString"/>
-       <Option value="1" name="horizontal_anchor_point" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="circle" name="name" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="35,35,35,255" name="outline_color" type="QString"/>
-       <Option value="solid" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="diameter" name="scale_method" type="QString"/>
-       <Option value="2" name="size" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-       <Option value="MM" name="size_unit" type="QString"/>
-       <Option value="1" name="vertical_anchor_point" type="QString"/>
+       <Option name="angle" type="QString" value="0"/>
+       <Option name="cap_style" type="QString" value="square"/>
+       <Option name="color" type="QString" value="213,180,60,255"/>
+       <Option name="horizontal_anchor_point" type="QString" value="1"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="name" type="QString" value="circle"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="35,35,35,255"/>
+       <Option name="outline_style" type="QString" value="solid"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="scale_method" type="QString" value="diameter"/>
+       <Option name="size" type="QString" value="2"/>
+       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="size_unit" type="QString" value="MM"/>
+       <Option name="vertical_anchor_point" type="QString" value="1"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem labelText="[% @cplus_model_scenario_name %]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="78" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="heading_two_level_two" frame="false" opacity="1" size="177.161,7.18097,mm" positionOnPage="29.0377,16.4569,mm" uuid="{82802665-4a3a-4367-9768-1e06afdd9584}" position="29.0377,16.4569,mm" templateUuid="{82802665-4a3a-4367-9768-1e06afdd9584}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="78" size="177.161,7.18097,mm" referencePoint="0" id="heading_two_level_two" templateUuid="{400e0bcf-47ab-49c1-be6a-44cffe7ee6eb}" positionOnPage="29.0377,16.4569,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_model_scenario_name %]" position="29.0377,16.4569,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{400e0bcf-47ab-49c1-be6a-44cffe7ee6eb}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="18" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="18" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="0" name="angle" type="QString"/>
-       <Option value="square" name="cap_style" type="QString"/>
-       <Option value="213,180,60,255" name="color" type="QString"/>
-       <Option value="1" name="horizontal_anchor_point" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="circle" name="name" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="35,35,35,255" name="outline_color" type="QString"/>
-       <Option value="solid" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="diameter" name="scale_method" type="QString"/>
-       <Option value="2" name="size" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-       <Option value="MM" name="size_unit" type="QString"/>
-       <Option value="1" name="vertical_anchor_point" type="QString"/>
+       <Option name="angle" type="QString" value="0"/>
+       <Option name="cap_style" type="QString" value="square"/>
+       <Option name="color" type="QString" value="213,180,60,255"/>
+       <Option name="horizontal_anchor_point" type="QString" value="1"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="name" type="QString" value="circle"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="35,35,35,255"/>
+       <Option name="outline_style" type="QString" value="solid"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="scale_method" type="QString" value="diameter"/>
+       <Option name="size" type="QString" value="2"/>
+       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="size_unit" type="QString" value="MM"/>
+       <Option name="vertical_anchor_point" type="QString" value="1"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="77" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="heading_background_one" frame="false" opacity="1" size="210,25.8685,mm" positionOnPage="0,0,mm" uuid="{6e2e1380-39e5-4840-ae7f-bd327acc57ac}" position="0,0,mm" templateUuid="{6e2e1380-39e5-4840-ae7f-bd327acc57ac}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="77" cornerRadiusMeasure="0,mm" size="210,25.8685,mm" shapeType="1" referencePoint="0" id="heading_background_one" templateUuid="{c26ca896-9600-40ba-a063-8e2c61920a4a}" positionOnPage="0,0,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0,0,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{c26ca896-9600-40ba-a063-8e2c61920a4a}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="3,109,0,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="3,109,0,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem type="65640" frameJoinStyle="miter" svgBorderColor="0,0,0,255" visibility="1" blendMode="0" referencePoint="0" svgFillColor="255,255,255,255" pictureWidth="5.32553" zValue="76" excludeFromExports="0" resizeMode="0" mode="2" background="false" anchorPoint="0" outlineWidthM="0.3,mm" svgBorderWidth="0.2" positionLock="false" pictureRotation="0" mapUuid="" id="north_arrow_one" frame="false" opacity="1" file=":/images/north_arrows/layout_default_north_arrow.svg" size="6.31047,6.72239,mm" positionOnPage="180.049,167.814,mm" uuid="{dcacdebd-6740-426c-8f50-9fd78cba7f42}" position="180.049,167.814,mm" templateUuid="{dcacdebd-6740-426c-8f50-9fd78cba7f42}" itemRotation="0" pictureHeight="6.72239" northOffset="0" groupUuid="" northMode="0">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="76" size="6.31047,6.72239,mm" referencePoint="0" resizeMode="0" id="north_arrow_one" svgFillColor="255,255,255,255" templateUuid="{fc61f03d-ca85-4ce1-86c7-a202e88a17f0}" mode="2" positionOnPage="180.049,167.814,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="5.32553" svgBorderWidth="0.2" mapUuid="" position="180.049,167.814,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file=":/images/north_arrows/layout_default_north_arrow.svg" northOffset="0" svgBorderColor="0,0,0,255" uuid="{fc61f03d-ca85-4ce1-86c7-a202e88a17f0}" pictureHeight="6.72239" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -435,304 +435,304 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem referencePoint="0" labelBarSpace="1" mapUuid="{a2623fce-25e8-4e1b-b396-22976faff32b}" numSubdivisions="1" unitLabel="km" labelHorizontalPlacement="1" lineCapStyle="square" numUnitsPerSegment="9e-05" subdivisionsHeight="1.5" maxBarWidth="40" outlineWidth="0.3" boxContentSpace="1" blendMode="0" alignment="0" style="Single Box" uuid="{792faf03-343f-47df-9d79-ba5334495794}" positionOnPage="162.85,176.637,mm" type="65646" excludeFromExports="0" itemRotation="0" groupUuid="" position="162.85,176.637,mm" frameJoinStyle="miter" background="true" labelVerticalPlacement="0" id="scalebar_map_one" minBarWidth="20" lineJoinStyle="miter" numMapUnitsPerScaleBarUnit="1" unitType="km" opacity="1" positionLock="false" numSegments="2" outlineWidthM="0.3,mm" templateUuid="{792faf03-343f-47df-9d79-ba5334495794}" segmentMillimeters="19.0544" zValue="75" segmentSizeMode="1" visibility="1" frame="false" height="2" numSegmentsLeft="0" size="40.7087,9.33,mm">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="181" red="255" green="255" blue="255"/>
+ <LayoutItem lineCapStyle="square" numSegmentsLeft="0" numMapUnitsPerScaleBarUnit="1" minBarWidth="20" templateUuid="{22d9295f-3ae7-4686-8797-da94b8b0f2fa}" zValue="75" mapUuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" height="2" labelHorizontalPlacement="1" id="scalebar_map_one" labelVerticalPlacement="0" boxContentSpace="1" frameJoinStyle="miter" labelBarSpace="1" unitType="km" numUnitsPerSegment="9" alignment="0" excludeFromExports="0" background="true" frame="false" visibility="1" segmentSizeMode="1" maxBarWidth="40" unitLabel="km" numSubdivisions="1" size="40.3232,9.33,mm" positionLock="false" referencePoint="4" type="65646" itemRotation="0" outlineWidthM="0.3,mm" opacity="1" position="183.204,181.302,mm" uuid="{22d9295f-3ae7-4686-8797-da94b8b0f2fa}" style="Single Box" lineJoinStyle="miter" groupUuid="" outlineWidth="0.3" subdivisionsHeight="1.5" blendMode="0" numSegments="2" segmentMillimeters="18.8616" positionOnPage="183.204,181.302,mm">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="181"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="8" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="8" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
-  <strokeColor alpha="255" red="0" green="0" blue="0"/>
+  <strokeColor red="0" green="0" blue="0" alpha="255"/>
   <numericFormat id="basic">
    <Option type="Map">
     <Option name="decimal_separator" type="invalid"/>
-    <Option value="6" name="decimals" type="int"/>
-    <Option value="0" name="rounding_type" type="int"/>
-    <Option value="false" name="show_plus" type="bool"/>
-    <Option value="true" name="show_thousand_separator" type="bool"/>
-    <Option value="false" name="show_trailing_zeros" type="bool"/>
+    <Option name="decimals" type="int" value="6"/>
+    <Option name="rounding_type" type="int" value="0"/>
+    <Option name="show_plus" type="bool" value="false"/>
+    <Option name="show_thousand_separator" type="bool" value="true"/>
+    <Option name="show_trailing_zeros" type="bool" value="false"/>
     <Option name="thousand_separator" type="invalid"/>
    </Option>
   </numericFormat>
-  <fillColor alpha="255" red="0" green="0" blue="0"/>
-  <fillColor2 alpha="255" red="255" green="255" blue="255"/>
+  <fillColor red="0" green="0" blue="0" alpha="255"/>
+  <fillColor2 red="255" green="255" blue="255" alpha="255"/>
   <lineSymbol>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="line">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleLine" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
+    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
      <Option type="Map">
-      <Option value="0" name="align_dash_pattern" type="QString"/>
-      <Option value="square" name="capstyle" type="QString"/>
-      <Option value="5;2" name="customdash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-      <Option value="MM" name="customdash_unit" type="QString"/>
-      <Option value="0" name="dash_pattern_offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-      <Option value="0" name="draw_inside_polygon" type="QString"/>
-      <Option value="miter" name="joinstyle" type="QString"/>
-      <Option value="0,0,0,255" name="line_color" type="QString"/>
-      <Option value="solid" name="line_style" type="QString"/>
-      <Option value="0.3" name="line_width" type="QString"/>
-      <Option value="MM" name="line_width_unit" type="QString"/>
-      <Option value="0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="0" name="ring_filter" type="QString"/>
-      <Option value="0" name="trim_distance_end" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-      <Option value="0" name="trim_distance_start" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-      <Option value="0" name="use_custom_dash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+      <Option name="align_dash_pattern" type="QString" value="0"/>
+      <Option name="capstyle" type="QString" value="square"/>
+      <Option name="customdash" type="QString" value="5;2"/>
+      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="customdash_unit" type="QString" value="MM"/>
+      <Option name="dash_pattern_offset" type="QString" value="0"/>
+      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+      <Option name="draw_inside_polygon" type="QString" value="0"/>
+      <Option name="joinstyle" type="QString" value="miter"/>
+      <Option name="line_color" type="QString" value="0,0,0,255"/>
+      <Option name="line_style" type="QString" value="solid"/>
+      <Option name="line_width" type="QString" value="0.3"/>
+      <Option name="line_width_unit" type="QString" value="MM"/>
+      <Option name="offset" type="QString" value="0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="ring_filter" type="QString" value="0"/>
+      <Option name="trim_distance_end" type="QString" value="0"/>
+      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+      <Option name="trim_distance_start" type="QString" value="0"/>
+      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+      <Option name="use_custom_dash" type="QString" value="0"/>
+      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </lineSymbol>
   <divisionLineSymbol>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="line">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleLine" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
+    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
      <Option type="Map">
-      <Option value="0" name="align_dash_pattern" type="QString"/>
-      <Option value="square" name="capstyle" type="QString"/>
-      <Option value="5;2" name="customdash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-      <Option value="MM" name="customdash_unit" type="QString"/>
-      <Option value="0" name="dash_pattern_offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-      <Option value="0" name="draw_inside_polygon" type="QString"/>
-      <Option value="miter" name="joinstyle" type="QString"/>
-      <Option value="0,0,0,255" name="line_color" type="QString"/>
-      <Option value="solid" name="line_style" type="QString"/>
-      <Option value="0.3" name="line_width" type="QString"/>
-      <Option value="MM" name="line_width_unit" type="QString"/>
-      <Option value="0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="0" name="ring_filter" type="QString"/>
-      <Option value="0" name="trim_distance_end" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-      <Option value="0" name="trim_distance_start" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-      <Option value="0" name="use_custom_dash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+      <Option name="align_dash_pattern" type="QString" value="0"/>
+      <Option name="capstyle" type="QString" value="square"/>
+      <Option name="customdash" type="QString" value="5;2"/>
+      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="customdash_unit" type="QString" value="MM"/>
+      <Option name="dash_pattern_offset" type="QString" value="0"/>
+      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+      <Option name="draw_inside_polygon" type="QString" value="0"/>
+      <Option name="joinstyle" type="QString" value="miter"/>
+      <Option name="line_color" type="QString" value="0,0,0,255"/>
+      <Option name="line_style" type="QString" value="solid"/>
+      <Option name="line_width" type="QString" value="0.3"/>
+      <Option name="line_width_unit" type="QString" value="MM"/>
+      <Option name="offset" type="QString" value="0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="ring_filter" type="QString" value="0"/>
+      <Option name="trim_distance_end" type="QString" value="0"/>
+      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+      <Option name="trim_distance_start" type="QString" value="0"/>
+      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+      <Option name="use_custom_dash" type="QString" value="0"/>
+      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </divisionLineSymbol>
   <subdivisionLineSymbol>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="line">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="line" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleLine" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}">
+    <layer class="SimpleLine" pass="0" enabled="1" id="{e514be45-f1a2-4b02-96b9-5e4a27b1c365}" locked="0">
      <Option type="Map">
-      <Option value="0" name="align_dash_pattern" type="QString"/>
-      <Option value="square" name="capstyle" type="QString"/>
-      <Option value="5;2" name="customdash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
-      <Option value="MM" name="customdash_unit" type="QString"/>
-      <Option value="0" name="dash_pattern_offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
-      <Option value="0" name="draw_inside_polygon" type="QString"/>
-      <Option value="miter" name="joinstyle" type="QString"/>
-      <Option value="0,0,0,255" name="line_color" type="QString"/>
-      <Option value="solid" name="line_style" type="QString"/>
-      <Option value="0.3" name="line_width" type="QString"/>
-      <Option value="MM" name="line_width_unit" type="QString"/>
-      <Option value="0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="0" name="ring_filter" type="QString"/>
-      <Option value="0" name="trim_distance_end" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_end_unit" type="QString"/>
-      <Option value="0" name="trim_distance_start" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
-      <Option value="MM" name="trim_distance_start_unit" type="QString"/>
-      <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
-      <Option value="0" name="use_custom_dash" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+      <Option name="align_dash_pattern" type="QString" value="0"/>
+      <Option name="capstyle" type="QString" value="square"/>
+      <Option name="customdash" type="QString" value="5;2"/>
+      <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="customdash_unit" type="QString" value="MM"/>
+      <Option name="dash_pattern_offset" type="QString" value="0"/>
+      <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+      <Option name="draw_inside_polygon" type="QString" value="0"/>
+      <Option name="joinstyle" type="QString" value="miter"/>
+      <Option name="line_color" type="QString" value="0,0,0,255"/>
+      <Option name="line_style" type="QString" value="solid"/>
+      <Option name="line_width" type="QString" value="0.3"/>
+      <Option name="line_width_unit" type="QString" value="MM"/>
+      <Option name="offset" type="QString" value="0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="ring_filter" type="QString" value="0"/>
+      <Option name="trim_distance_end" type="QString" value="0"/>
+      <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+      <Option name="trim_distance_start" type="QString" value="0"/>
+      <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+      <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+      <Option name="use_custom_dash" type="QString" value="0"/>
+      <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </subdivisionLineSymbol>
   <fillSymbol1>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{5e8caacb-d09f-4173-92cf-6ae80d1ca6ee}">
+    <layer class="SimpleFill" pass="0" enabled="1" id="{5e8caacb-d09f-4173-92cf-6ae80d1ca6ee}" locked="0">
      <Option type="Map">
-      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-      <Option value="0,0,0,255" name="color" type="QString"/>
-      <Option value="bevel" name="joinstyle" type="QString"/>
-      <Option value="0,0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="35,35,35,255" name="outline_color" type="QString"/>
-      <Option value="no" name="outline_style" type="QString"/>
-      <Option value="0.26" name="outline_width" type="QString"/>
-      <Option value="MM" name="outline_width_unit" type="QString"/>
-      <Option value="solid" name="style" type="QString"/>
+      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="color" type="QString" value="0,0,0,255"/>
+      <Option name="joinstyle" type="QString" value="bevel"/>
+      <Option name="offset" type="QString" value="0,0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="outline_color" type="QString" value="35,35,35,255"/>
+      <Option name="outline_style" type="QString" value="no"/>
+      <Option name="outline_width" type="QString" value="0.26"/>
+      <Option name="outline_width_unit" type="QString" value="MM"/>
+      <Option name="style" type="QString" value="solid"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </fillSymbol1>
   <fillSymbol2>
-   <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+   <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
-    <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{60d585c6-c72a-42d3-8050-d0102f88ce38}">
+    <layer class="SimpleFill" pass="0" enabled="1" id="{60d585c6-c72a-42d3-8050-d0102f88ce38}" locked="0">
      <Option type="Map">
-      <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-      <Option value="255,255,255,255" name="color" type="QString"/>
-      <Option value="bevel" name="joinstyle" type="QString"/>
-      <Option value="0,0" name="offset" type="QString"/>
-      <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-      <Option value="MM" name="offset_unit" type="QString"/>
-      <Option value="35,35,35,255" name="outline_color" type="QString"/>
-      <Option value="no" name="outline_style" type="QString"/>
-      <Option value="0.26" name="outline_width" type="QString"/>
-      <Option value="MM" name="outline_width_unit" type="QString"/>
-      <Option value="solid" name="style" type="QString"/>
+      <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="color" type="QString" value="255,255,255,255"/>
+      <Option name="joinstyle" type="QString" value="bevel"/>
+      <Option name="offset" type="QString" value="0,0"/>
+      <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+      <Option name="offset_unit" type="QString" value="MM"/>
+      <Option name="outline_color" type="QString" value="35,35,35,255"/>
+      <Option name="outline_style" type="QString" value="no"/>
+      <Option name="outline_width" type="QString" value="0.26"/>
+      <Option name="outline_width_unit" type="QString" value="MM"/>
+      <Option name="style" type="QString" value="solid"/>
      </Option>
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
     </layer>
    </symbol>
   </fillSymbol2>
  </LayoutItem>
- <LayoutItem maxSymbolSize="0" resizeToContents="0" referencePoint="0" symbolWidth="3" splitLayer="1" map_uuid="{a2623fce-25e8-4e1b-b396-22976faff32b}" wmsLegendHeight="25" boxSpace="2" legendFilterByAtlas="0" blendMode="0" rasterBorderWidth="0" columnSpace="2" minSymbolSize="0" title="Ideal Landuse" uuid="{e4c53346-7a50-4e81-92b6-dfb17e46a6ac}" positionOnPage="130.315,25.8685,mm" type="65642" excludeFromExports="0" rasterBorder="1" itemRotation="0" groupUuid="" position="130.315,25.8685,mm" titleAlignment="1" frameJoinStyle="miter" background="true" wmsLegendWidth="50" columnCount="1" id="legend_main_map" opacity="1" positionLock="false" symbolHeight="3" equalColumnWidth="0" outlineWidthM="0.3,mm" symbolAlignment="1" templateUuid="{e4c53346-7a50-4e81-92b6-dfb17e46a6ac}" zValue="74" legendFilterByMap="1" wrapChar="" visibility="1" frame="false" size="80,90.789,mm" rasterBorderColor="0,0,0,255">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="185" red="255" green="255" blue="255"/>
+ <LayoutItem legendFilterByAtlas="0" symbolAlignment="1" rasterBorderColor="0,0,0,255" legendFilterByMap="1" templateUuid="{decb0471-87d4-4984-a05d-49611a711c88}" zValue="74" splitLayer="1" wrapChar="" id="legend_main_map" frameJoinStyle="miter" resizeToContents="0" symbolWidth="3" map_uuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" wmsLegendWidth="50" columnSpace="2" title="" excludeFromExports="0" background="true" frame="false" rasterBorder="1" visibility="1" minSymbolSize="0" size="75.3434,94.0442,mm" positionLock="false" referencePoint="0" type="65642" itemRotation="0" titleAlignment="1" outlineWidthM="0.3,mm" opacity="1" position="134.655,25.8685,mm" uuid="{decb0471-87d4-4984-a05d-49611a711c88}" wmsLegendHeight="25" symbolHeight="3" rasterBorderWidth="0" boxSpace="2" columnCount="1" groupUuid="" blendMode="0" equalColumnWidth="0" positionOnPage="134.655,25.8685,mm" maxSymbolSize="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="185"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -740,691 +740,769 @@
    </customproperties>
   </LayoutObject>
   <styles>
-   <style name="title" alignment="1" marginBottom="3.5" indent="0">
-    <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1.1000000000000001" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="0" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <style name="title" alignment="1" indent="0">
+    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="14" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="75" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Bold" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
      <families/>
-     <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-     <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-     <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-      <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+      <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
-       <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+       <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
         <Option type="Map">
-         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-         <Option value="255,255,255,255" name="color" type="QString"/>
-         <Option value="bevel" name="joinstyle" type="QString"/>
-         <Option value="0,0" name="offset" type="QString"/>
-         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-         <Option value="MM" name="offset_unit" type="QString"/>
-         <Option value="128,128,128,255" name="outline_color" type="QString"/>
-         <Option value="no" name="outline_style" type="QString"/>
-         <Option value="0" name="outline_width" type="QString"/>
-         <Option value="MM" name="outline_width_unit" type="QString"/>
-         <Option value="solid" name="style" type="QString"/>
+         <Option name="angle" type="QString" value="0"/>
+         <Option name="cap_style" type="QString" value="square"/>
+         <Option name="color" type="QString" value="164,113,88,255"/>
+         <Option name="horizontal_anchor_point" type="QString" value="1"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="name" type="QString" value="circle"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="35,35,35,255"/>
+         <Option name="outline_style" type="QString" value="solid"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="scale_method" type="QString" value="diameter"/>
+         <Option name="size" type="QString" value="2"/>
+         <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="size_unit" type="QString" value="MM"/>
+         <Option name="vertical_anchor_point" type="QString" value="1"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option value="" name="name" type="QString"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="type" type="QString" value="collection"/>
+         </Option>
+        </data_defined_properties>
+       </layer>
+      </symbol>
+      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+       <data_defined_properties>
+        <Option type="Map">
+         <Option name="name" type="QString" value=""/>
+         <Option name="properties"/>
+         <Option name="type" type="QString" value="collection"/>
+        </Option>
+       </data_defined_properties>
+       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+        <Option type="Map">
+         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="color" type="QString" value="255,255,255,255"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="128,128,128,255"/>
+         <Option name="outline_style" type="QString" value="no"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="style" type="QString" value="solid"/>
+        </Option>
+        <data_defined_properties>
+         <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
      <dd_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="group" marginTop="3" alignment="1" indent="0">
-    <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1.1000000000000001" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="0" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <style name="group" alignment="1" indent="0">
+    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="0" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
      <families/>
-     <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-     <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-     <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-      <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
-       <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
         <Option type="Map">
-         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-         <Option value="255,255,255,255" name="color" type="QString"/>
-         <Option value="bevel" name="joinstyle" type="QString"/>
-         <Option value="0,0" name="offset" type="QString"/>
-         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-         <Option value="MM" name="offset_unit" type="QString"/>
-         <Option value="128,128,128,255" name="outline_color" type="QString"/>
-         <Option value="no" name="outline_style" type="QString"/>
-         <Option value="0" name="outline_width" type="QString"/>
-         <Option value="MM" name="outline_width_unit" type="QString"/>
-         <Option value="solid" name="style" type="QString"/>
+         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="color" type="QString" value="255,255,255,255"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="128,128,128,255"/>
+         <Option name="outline_style" type="QString" value="no"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="style" type="QString" value="solid"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option value="" name="name" type="QString"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="type" type="QString" value="collection"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
      <dd_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="subgroup" marginTop="3" alignment="1" indent="0">
-    <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1.1000000000000001" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="12" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <style name="subgroup" alignment="1" indent="0">
+    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="16" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="75" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Bold" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
      <families/>
-     <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-     <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-     <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-      <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+      <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
-       <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+       <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
         <Option type="Map">
-         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-         <Option value="255,255,255,255" name="color" type="QString"/>
-         <Option value="bevel" name="joinstyle" type="QString"/>
-         <Option value="0,0" name="offset" type="QString"/>
-         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-         <Option value="MM" name="offset_unit" type="QString"/>
-         <Option value="128,128,128,255" name="outline_color" type="QString"/>
-         <Option value="no" name="outline_style" type="QString"/>
-         <Option value="0" name="outline_width" type="QString"/>
-         <Option value="MM" name="outline_width_unit" type="QString"/>
-         <Option value="solid" name="style" type="QString"/>
+         <Option name="angle" type="QString" value="0"/>
+         <Option name="cap_style" type="QString" value="square"/>
+         <Option name="color" type="QString" value="255,158,23,255"/>
+         <Option name="horizontal_anchor_point" type="QString" value="1"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="name" type="QString" value="circle"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="35,35,35,255"/>
+         <Option name="outline_style" type="QString" value="solid"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="scale_method" type="QString" value="diameter"/>
+         <Option name="size" type="QString" value="2"/>
+         <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="size_unit" type="QString" value="MM"/>
+         <Option name="vertical_anchor_point" type="QString" value="1"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option value="" name="name" type="QString"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="type" type="QString" value="collection"/>
+         </Option>
+        </data_defined_properties>
+       </layer>
+      </symbol>
+      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
+       <data_defined_properties>
+        <Option type="Map">
+         <Option name="name" type="QString" value=""/>
+         <Option name="properties"/>
+         <Option name="type" type="QString" value="collection"/>
+        </Option>
+       </data_defined_properties>
+       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
+        <Option type="Map">
+         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="color" type="QString" value="255,255,255,255"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="128,128,128,255"/>
+         <Option name="outline_style" type="QString" value="no"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="style" type="QString" value="solid"/>
+        </Option>
+        <data_defined_properties>
+         <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
      <dd_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="symbol" marginTop="2.5" alignment="1" indent="0">
-    <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="10" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <style marginTop="2.5" name="symbol" alignment="1" indent="0">
+    <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="10" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
      <families/>
-     <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-     <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-     <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-      <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
-       <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
         <Option type="Map">
-         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-         <Option value="255,255,255,255" name="color" type="QString"/>
-         <Option value="bevel" name="joinstyle" type="QString"/>
-         <Option value="0,0" name="offset" type="QString"/>
-         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-         <Option value="MM" name="offset_unit" type="QString"/>
-         <Option value="128,128,128,255" name="outline_color" type="QString"/>
-         <Option value="no" name="outline_style" type="QString"/>
-         <Option value="0" name="outline_width" type="QString"/>
-         <Option value="MM" name="outline_width_unit" type="QString"/>
-         <Option value="solid" name="style" type="QString"/>
+         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="color" type="QString" value="255,255,255,255"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="128,128,128,255"/>
+         <Option name="outline_style" type="QString" value="no"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="style" type="QString" value="solid"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option value="" name="name" type="QString"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="type" type="QString" value="collection"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
      <dd_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
-   <style name="symbolLabel" marginTop="2" marginLeft="2" alignment="1" indent="0">
-    <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1.1000000000000001" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="8" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <style marginTop="2" name="symbolLabel" alignment="1" indent="0" marginLeft="2">
+    <text-style fontUnderline="0" multilineHeight="1.1000000000000001" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="8" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
      <families/>
-     <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-     <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-     <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-      <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+     <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+     <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+      <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
-       <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+       <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
         <Option type="Map">
-         <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-         <Option value="255,255,255,255" name="color" type="QString"/>
-         <Option value="bevel" name="joinstyle" type="QString"/>
-         <Option value="0,0" name="offset" type="QString"/>
-         <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-         <Option value="MM" name="offset_unit" type="QString"/>
-         <Option value="128,128,128,255" name="outline_color" type="QString"/>
-         <Option value="no" name="outline_style" type="QString"/>
-         <Option value="0" name="outline_width" type="QString"/>
-         <Option value="MM" name="outline_width_unit" type="QString"/>
-         <Option value="solid" name="style" type="QString"/>
+         <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="color" type="QString" value="255,255,255,255"/>
+         <Option name="joinstyle" type="QString" value="bevel"/>
+         <Option name="offset" type="QString" value="0,0"/>
+         <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+         <Option name="offset_unit" type="QString" value="MM"/>
+         <Option name="outline_color" type="QString" value="128,128,128,255"/>
+         <Option name="outline_style" type="QString" value="no"/>
+         <Option name="outline_width" type="QString" value="0"/>
+         <Option name="outline_width_unit" type="QString" value="MM"/>
+         <Option name="style" type="QString" value="solid"/>
         </Option>
         <data_defined_properties>
          <Option type="Map">
-          <Option value="" name="name" type="QString"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option value="collection" name="type" type="QString"/>
+          <Option name="type" type="QString" value="collection"/>
          </Option>
         </data_defined_properties>
        </layer>
       </symbol>
      </background>
-     <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+     <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
      <dd_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </dd_properties>
     </text-style>
    </style>
   </styles>
  </LayoutItem>
- <LayoutItem followPresetName="Final Scenario" type="65639" mapRotation="0" frameJoinStyle="miter" visibility="1" labelMargin="0,mm" blendMode="0" referencePoint="0" followPreset="true" zValue="73" excludeFromExports="0" background="true" outlineWidthM="0.3,mm" positionLock="false" id="map_one_scenario" isTemporal="0" frame="false" opacity="1" size="210.014,160.099,mm" positionOnPage="0,25.8685,mm" uuid="{a2623fce-25e8-4e1b-b396-22976faff32b}" position="0,25.8685,mm" templateUuid="{a2623fce-25e8-4e1b-b396-22976faff32b}" itemRotation="0" keepLayerSet="false" drawCanvasItems="true" mapFlags="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="73" size="210.014,160.099,mm" labelMargin="0,mm" referencePoint="0" id="map_one_scenario" templateUuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" positionOnPage="0,25.8685,mm" background="true" frameJoinStyle="miter" mapRotation="0" type="65639" mapFlags="0" groupUuid="" blendMode="0" followPresetName="Final Scenario" outlineWidthM="0.3,mm" drawCanvasItems="true" keepLayerSet="false" position="0,25.8685,mm" isTemporal="0" visibility="1" itemRotation="0" positionLock="false" uuid="{2dddc04e-3009-4b73-9abc-650c88934f6c}" opacity="1" frame="false" excludeFromExports="0" followPreset="true">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <Extent xmax="31.53033795188935784" ymax="-24.47990663749100904" xmin="30.53573927524800524" ymin="-25.23811207252041555"/>
+  <Extent xmin="30.53573927524800524" ymin="-25.23811207252041555" ymax="-24.47990663749100904" xmax="31.53033795188935784"/>
   <LayerSet/>
-  <AtlasMap margin="0.10000000000000001" atlasDriven="0" scalingMode="2"/>
+  <AtlasMap scalingMode="2" atlasDriven="0" margin="0.10000000000000001"/>
   <labelBlockingItems/>
-  <atlasClippingSettings enabled="0" forceLabelsInside="0" restrictLayers="0" clippingType="1">
+  <atlasClippingSettings clippingType="1" forceLabelsInside="0" restrictLayers="0" enabled="0">
    <layersToClip/>
   </atlasClippingSettings>
-  <itemClippingSettings clipSource="" enabled="0" forceLabelsInside="0" clippingType="1"/>
+  <itemClippingSettings clippingType="1" forceLabelsInside="0" clipSource="" enabled="0"/>
  </LayoutItem>
- <LayoutItem labelText="Scenario Summary" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="72" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="4" marginY="0" positionLock="false" valign="128" htmlState="0" id="heading_three_level_three" frame="false" opacity="1" size="210.362,11.5546,mm" positionOnPage="-0.36335,185.967,mm" uuid="{dfcffef5-4638-482e-a909-b8157f0ae02e}" position="-0.36335,185.967,mm" templateUuid="{dfcffef5-4638-482e-a909-b8157f0ae02e}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="72" size="210.362,11.5546,mm" referencePoint="0" id="heading_three_level_three" templateUuid="{538f9125-82fa-4f2e-8e4a-b6fa5691ec4b}" positionOnPage="-0.36335,185.967,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Summary" position="-0.36335,185.967,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{538f9125-82fa-4f2e-8e4a-b6fa5691ec4b}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="17" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="17" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="71" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="heading_background_two" frame="false" opacity="1" size="210.04,11.5546,mm" positionOnPage="-0.02595,185.967,mm" uuid="{f43358e7-574d-415e-9bf4-4253e412b117}" position="-0.02595,185.967,mm" templateUuid="{f43358e7-574d-415e-9bf4-4253e412b117}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="71" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm" shapeType="1" referencePoint="0" id="heading_background_two" templateUuid="{138b6be8-9ecd-4578-a677-652d43e328f1}" positionOnPage="-0.02595,185.967,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-0.02595,185.967,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{138b6be8-9ecd-4578-a677-652d43e328f1}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="3,109,0,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="3,109,0,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem labelText="[% @cplus_model_scenario_description %]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="1" zValue="70" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0.5" positionLock="false" valign="32" htmlState="0" id="scenario_description" frame="false" opacity="1" size="210,13.799,mm" positionOnPage="0.01394,197.522,mm" uuid="{471929c6-04b4-475e-83bf-564b4d3af950}" position="0.01394,197.522,mm" templateUuid="{471929c6-04b4-475e-83bf-564b4d3af950}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="70" size="210,13.799,mm" referencePoint="0" id="scenario_description" templateUuid="{f150520a-9cc5-4085-be5c-92638b682547}" positionOnPage="0.01394,197.522,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="1" valign="32" labelText="[% @cplus_model_scenario_description %]" position="0.01394,197.522,mm" visibility="1" itemRotation="0" marginY="0.5" positionLock="false" halign="1" uuid="{f150520a-9cc5-4085-be5c-92638b682547}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="11" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="11" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem labelText="Scenario Summary Statistics" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="69" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="4" marginY="0" positionLock="false" valign="128" htmlState="0" id="heading_four_left" frame="false" opacity="1" size="105.78,11.5546,mm" positionOnPage="0.01394,211.321,mm" uuid="{288629b0-3c97-4c57-b33f-66e40551ed40}" position="0.01394,211.321,mm" templateUuid="{288629b0-3c97-4c57-b33f-66e40551ed40}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="69" size="105.78,11.5546,mm" referencePoint="0" id="heading_four_left" templateUuid="{b1793ad7-f1b0-4d56-93bb-b1ab3e256833}" positionOnPage="0.01394,211.321,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Summary Statistics" position="0.01394,211.321,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{b1793ad7-f1b0-4d56-93bb-b1ab3e256833}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="13" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="13" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem labelText="Scenario Weighting Values" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="68" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="4" marginY="0" positionLock="false" valign="128" htmlState="0" id="heading_four_right" frame="false" opacity="1" size="104.52,11.5546,mm" positionOnPage="105.794,211.321,mm" uuid="{2cf027a2-f2cd-4988-b921-f6c2a9564a3e}" position="105.794,211.321,mm" templateUuid="{2cf027a2-f2cd-4988-b921-f6c2a9564a3e}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="68" size="104.52,11.5546,mm" referencePoint="0" id="heading_four_right" templateUuid="{2579db44-1aff-4620-ae69-1e8e0a1402d1}" positionOnPage="105.794,211.321,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="128" labelText="Scenario Weighting Values" position="105.794,211.321,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="4" uuid="{2579db44-1aff-4620-ae69-1e8e0a1402d1}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="13" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="13" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="67" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="heading_background_three" frame="false" opacity="1" size="210.04,11.5546,mm" positionOnPage="0.01394,211.321,mm" uuid="{a11deb4d-a4a5-4189-82fd-3f9295424ca8}" position="0.01394,211.321,mm" templateUuid="{a11deb4d-a4a5-4189-82fd-3f9295424ca8}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="67" cornerRadiusMeasure="0,mm" size="210.04,11.5546,mm" shapeType="1" referencePoint="0" id="heading_background_three" templateUuid="{b278f8e7-2751-44b6-9798-d4c9ba2c4653}" positionOnPage="0.01394,211.321,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0.01394,211.321,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{b278f8e7-2751-44b6-9798-d4c9ba2c4653}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="178,223,138,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="178,223,138,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem labelText="[% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="59" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="accreditation_text" frame="false" opacity="1" size="167.683,15.6086,mm" positionOnPage="2.76111,279.287,mm" uuid="{17c961c4-0ac8-4cc8-b4d6-4ffab2ff9669}" position="2.76111,279.287,mm" templateUuid="{17c961c4-0ac8-4cc8-b4d6-4ffab2ff9669}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="59" size="167.683,15.6086,mm" referencePoint="0" id="accreditation_text" templateUuid="{3465f3e9-2f63-4b76-8ffd-b8997aa3fc01}" positionOnPage="2.76111,279.287,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" position="2.76111,279.287,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{3465f3e9-2f63-4b76-8ffd-b8997aa3fc01}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="7.5" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="7.5" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65640" frameJoinStyle="miter" svgBorderColor="0,0,0,255" visibility="1" blendMode="0" referencePoint="0" svgFillColor="255,255,255,255" pictureWidth="34.0522" zValue="57" excludeFromExports="0" resizeMode="0" mode="0" background="false" anchorPoint="0" outlineWidthM="0.3,mm" svgBorderWidth="0.2" positionLock="false" pictureRotation="0" mapUuid="" id="logo_2" frame="false" opacity="1" file="" size="37.1491,14.1884,mm" positionOnPage="171.763,279.287,mm" uuid="{3a2e37d5-3a1a-4661-95a4-c2b0ac8e6f3d}" position="171.763,279.287,mm" templateUuid="{3a2e37d5-3a1a-4661-95a4-c2b0ac8e6f3d}" itemRotation="0" pictureHeight="14.1884" northOffset="0" groupUuid="" northMode="0">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="57" size="37.1491,14.1884,mm" referencePoint="0" resizeMode="0" id="logo_2" svgFillColor="255,255,255,255" templateUuid="{83465577-91a1-46be-b7ab-59eb0f4371c5}" mode="0" positionOnPage="171.763,279.287,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="34.0522" svgBorderWidth="0.2" mapUuid="" position="171.763,279.287,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{83465577-91a1-46be-b7ab-59eb0f4371c5}" pictureHeight="14.1884" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option value="true" name="active" type="bool"/>
-       <Option value="@cplus_setting_ci_logo" name="expression" type="QString"/>
-       <Option value="3" name="type" type="int"/>
+       <Option name="active" type="bool" value="true"/>
+       <Option name="expression" type="QString" value="@cplus_setting_ci_logo"/>
+       <Option name="type" type="int" value="3"/>
       </Option>
      </Option>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1432,130 +1510,130 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem labelText="[% @layout_page %]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="56" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="page_number_1" frame="false" opacity="1" size="3.62469,4.75988,mm" positionOnPage="103.982,291.095,mm" uuid="{20240590-2a72-454c-ae57-2e6b514b11dd}" position="103.982,291.095,mm" templateUuid="{20240590-2a72-454c-ae57-2e6b514b11dd}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="56" size="3.62469,4.75988,mm" referencePoint="0" id="page_number_1" templateUuid="{cb4656f7-9f0e-420b-a4a7-d5e6212ade9f}" positionOnPage="103.982,291.095,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @layout_page %]" position="103.982,291.095,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{cb4656f7-9f0e-420b-a4a7-d5e6212ade9f}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="12" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="55" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="footer_background" frame="false" opacity="1" size="210,21.238,mm" positionOnPage="0.01394,275.762,mm" uuid="{fb53d44e-fddb-40d4-9851-536ade922793}" position="0.01394,275.762,mm" templateUuid="{fb53d44e-fddb-40d4-9851-536ade922793}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="55" cornerRadiusMeasure="0,mm" size="210,21.238,mm" shapeType="1" referencePoint="0" id="footer_background" templateUuid="{b163af01-a421-4062-a00c-962da034fc1f}" positionOnPage="0.01394,275.762,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="0.01394,275.762,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{b163af01-a421-4062-a00c-962da034fc1f}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="3,109,0,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="3,109,0,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem type="65640" frameJoinStyle="miter" svgBorderColor="0,0,0,255" visibility="1" blendMode="0" referencePoint="0" svgFillColor="255,255,255,255" pictureWidth="21.0539" zValue="54" excludeFromExports="0" resizeMode="0" mode="0" background="true" anchorPoint="0" outlineWidthM="0.3,mm" svgBorderWidth="0.2" positionLock="false" pictureRotation="0" mapUuid="" id="title_logo_two" frame="false" opacity="1" file="" size="22.4124,21.0539,mm" positionOnPage="3.8525,2.584,mm" uuid="{439efba8-688d-4ae0-8405-0a2ca698e32b}" position="3.8525,309.584,mm" templateUuid="{439efba8-688d-4ae0-8405-0a2ca698e32b}" itemRotation="0" pictureHeight="21.0539" northOffset="0" groupUuid="" northMode="0">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="54" size="22.4124,21.0539,mm" referencePoint="0" resizeMode="0" id="title_logo_two" svgFillColor="255,255,255,255" templateUuid="{e7663c22-2f85-4e4e-8679-0ce82ba72f89}" mode="0" positionOnPage="3.8525,2.584,mm" background="true" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="21.0539" svgBorderWidth="0.2" mapUuid="" position="3.8525,309.584,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{e7663c22-2f85-4e4e-8679-0ce82ba72f89}" pictureHeight="21.0539" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option value="true" name="active" type="bool"/>
-       <Option value="@cplus_setting_cplus_logo" name="expression" type="QString"/>
-       <Option value="3" name="type" type="int"/>
+       <Option name="active" type="bool" value="true"/>
+       <Option name="expression" type="QString" value="@cplus_setting_cplus_logo"/>
+       <Option name="type" type="int" value="3"/>
       </Option>
      </Option>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1563,264 +1641,264 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem labelText="CPLUS Analysis Report&#xa;" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="53" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="heading_one_level_one_page_two" frame="false" opacity="1" size="176.922,12.3486,mm" positionOnPage="28.5781,2.584,mm" uuid="{15365c2c-7de0-424d-90f8-e7c76dd97f17}" position="28.5781,309.584,mm" templateUuid="{15365c2c-7de0-424d-90f8-e7c76dd97f17}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="53" size="176.922,12.3486,mm" referencePoint="0" id="heading_one_level_one_page_two" templateUuid="{035c1525-076a-4568-8872-42fe629bd19b}" positionOnPage="28.5781,2.584,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="CPLUS Analysis Report&#xa;" position="28.5781,309.584,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{035c1525-076a-4568-8872-42fe629bd19b}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="28" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="28" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="0" name="angle" type="QString"/>
-       <Option value="square" name="cap_style" type="QString"/>
-       <Option value="213,180,60,255" name="color" type="QString"/>
-       <Option value="1" name="horizontal_anchor_point" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="circle" name="name" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="35,35,35,255" name="outline_color" type="QString"/>
-       <Option value="solid" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="diameter" name="scale_method" type="QString"/>
-       <Option value="2" name="size" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-       <Option value="MM" name="size_unit" type="QString"/>
-       <Option value="1" name="vertical_anchor_point" type="QString"/>
+       <Option name="angle" type="QString" value="0"/>
+       <Option name="cap_style" type="QString" value="square"/>
+       <Option name="color" type="QString" value="213,180,60,255"/>
+       <Option name="horizontal_anchor_point" type="QString" value="1"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="name" type="QString" value="circle"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="35,35,35,255"/>
+       <Option name="outline_style" type="QString" value="solid"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="scale_method" type="QString" value="diameter"/>
+       <Option name="size" type="QString" value="2"/>
+       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="size_unit" type="QString" value="MM"/>
+       <Option name="vertical_anchor_point" type="QString" value="1"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem labelText="[% @cplus_model_scenario_name + ': Implementation Models'%]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="52" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="heading_two_level_two_page_two" frame="false" opacity="1" size="177.161,7.18097,mm" positionOnPage="29.0377,16.457,mm" uuid="{2b674b97-4a12-4b70-99e1-a16383e4dc31}" position="29.0377,323.457,mm" templateUuid="{2b674b97-4a12-4b70-99e1-a16383e4dc31}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="52" size="177.161,7.18097,mm" referencePoint="0" id="heading_two_level_two_page_two" templateUuid="{8adab953-08eb-44aa-b93e-8564439156da}" positionOnPage="29.0377,16.457,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @cplus_model_scenario_name + ': Implementation Models'%]" position="29.0377,323.457,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{8adab953-08eb-44aa-b93e-8564439156da}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="18" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="18" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+     <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="0" name="angle" type="QString"/>
-       <Option value="square" name="cap_style" type="QString"/>
-       <Option value="213,180,60,255" name="color" type="QString"/>
-       <Option value="1" name="horizontal_anchor_point" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="circle" name="name" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="35,35,35,255" name="outline_color" type="QString"/>
-       <Option value="solid" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="diameter" name="scale_method" type="QString"/>
-       <Option value="2" name="size" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-       <Option value="MM" name="size_unit" type="QString"/>
-       <Option value="1" name="vertical_anchor_point" type="QString"/>
+       <Option name="angle" type="QString" value="0"/>
+       <Option name="cap_style" type="QString" value="square"/>
+       <Option name="color" type="QString" value="213,180,60,255"/>
+       <Option name="horizontal_anchor_point" type="QString" value="1"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="name" type="QString" value="circle"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="35,35,35,255"/>
+       <Option name="outline_style" type="QString" value="solid"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="scale_method" type="QString" value="diameter"/>
+       <Option name="size" type="QString" value="2"/>
+       <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="size_unit" type="QString" value="MM"/>
+       <Option name="vertical_anchor_point" type="QString" value="1"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="51" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="heading_background_one_page_two" frame="false" opacity="1" size="210,25.8685,mm" positionOnPage="-1.42109e-14,0,mm" uuid="{e0984158-cc92-488a-82dc-7e99e31ff7c8}" position="-1.42109e-14,307,mm" templateUuid="{e0984158-cc92-488a-82dc-7e99e31ff7c8}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="51" cornerRadiusMeasure="0,mm" size="210,25.8685,mm" shapeType="1" referencePoint="0" id="heading_background_one_page_two" templateUuid="{da27c9df-6996-4e3c-9119-519154d64646}" positionOnPage="-1.42109e-14,0,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-1.42109e-14,307,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{da27c9df-6996-4e3c-9119-519154d64646}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="3,109,0,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="3,109,0,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem type="65647" multiFrame="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" sectionY="0" frameJoinStyle="miter" sectionHeight="42.7435" visibility="1" blendMode="0" referencePoint="0" multiFrameTemplateUuid="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" zValue="29" excludeFromExports="0" hideBackgroundIfEmpty="0" background="false" outlineWidthM="0.3,mm" positionLock="false" hidePageIfEmpty="0" id="implementation_model_area_table" frame="false" opacity="1" sectionX="0" size="60.4861,42.7435,mm" positionOnPage="-0.36335,224.486,mm" uuid="{7d4d4d5f-49b8-4e4e-8daf-33d26a01b50d}" position="-0.36335,224.486,mm" templateUuid="{7d4d4d5f-49b8-4e4e-8daf-33d26a01b50d}" itemRotation="0" sectionWidth="60.4861" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="29" size="60.4861,42.7435,mm" sectionHeight="42.7435" referencePoint="4" id="implementation_model_area_table" templateUuid="{23315901-e601-4914-a17b-da0615c317ad}" positionOnPage="52.9039,245.858,mm" background="false" frameJoinStyle="miter" type="65647" sectionX="0" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" multiFrame="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" position="52.9039,245.858,mm" visibility="1" itemRotation="0" sectionY="0" positionLock="false" uuid="{23315901-e601-4914-a17b-da0615c317ad}" multiFrameTemplateUuid="{549854bc-ee9b-4ae8-aad1-51c882ef6b4c}" hidePageIfEmpty="0" opacity="1" sectionWidth="60.4861" hideBackgroundIfEmpty="0" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1828,68 +1906,68 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem type="78000" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="27" excludeFromExports="0" modelComponentType="unknown" background="false" outlineWidthM="0.4,mm" positionLock="false" id="CPLUS Map Repeat Area 1" frame="true" opacity="1" size="210.014,248.479,mm" positionOnPage="9.8431e-17,25.868,mm" uuid="{95fcf000-4aa9-4eb2-98ed-e2cc81ec27bb}" position="9.8431e-17,332.868,mm" templateUuid="{95fcf000-4aa9-4eb2-98ed-e2cc81ec27bb}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="132" green="192" blue="68"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="27" cornerRadiusMeasure="0,mm" size="210.014,248.479,mm" shapeType="1" referencePoint="0" id="CPLUS Map Repeat Area 1" templateUuid="{7c2a6a3b-4d10-41bc-a8f1-a82b22184441}" positionOnPage="9.8431e-17,25.868,mm" background="false" frameJoinStyle="miter" type="78000" groupUuid="" blendMode="0" outlineWidthM="0.4,mm" modelComponentType="unknown" position="9.8431e-17,332.868,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{7c2a6a3b-4d10-41bc-a8f1-a82b22184441}" opacity="1" frame="true" excludeFromExports="0">
+  <FrameColor red="132" green="192" blue="68" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{2c0fd8a0-902f-4ee3-8782-ecc9cc4f313f}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{2c0fd8a0-902f-4ee3-8782-ecc9cc4f313f}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="229,182,54,0" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="132,192,68,255" name="outline_color" type="QString"/>
-     <Option value="dash" name="outline_style" type="QString"/>
-     <Option value="0" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="229,182,54,0"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="132,192,68,255"/>
+     <Option name="outline_style" type="QString" value="dash"/>
+     <Option name="outline_width" type="QString" value="0"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutItem type="65640" frameJoinStyle="miter" svgBorderColor="0,0,0,255" visibility="1" blendMode="0" referencePoint="0" svgFillColor="255,255,255,255" pictureWidth="34.0522" zValue="5" excludeFromExports="0" resizeMode="0" mode="0" background="false" anchorPoint="0" outlineWidthM="0.3,mm" svgBorderWidth="0.2" positionLock="false" pictureRotation="0" mapUuid="" id="logo_3" frame="false" opacity="1" file="" size="37.1491,14.1884,mm" positionOnPage="171.386,277.998,mm" uuid="{1c6217b3-8126-43b6-91d6-e6adaf52b9dc}" position="171.386,584.998,mm" templateUuid="{1c6217b3-8126-43b6-91d6-e6adaf52b9dc}" itemRotation="0" pictureHeight="14.1884" northOffset="0" groupUuid="" northMode="0">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="5" size="37.1491,14.1884,mm" referencePoint="0" resizeMode="0" id="logo_3" svgFillColor="255,255,255,255" templateUuid="{982bf0f3-407c-4126-a014-0d345a7427c4}" mode="0" positionOnPage="171.386,277.998,mm" background="false" frameJoinStyle="miter" type="65640" groupUuid="" blendMode="0" northMode="0" outlineWidthM="0.3,mm" pictureWidth="34.0522" svgBorderWidth="0.2" mapUuid="" position="171.386,584.998,mm" visibility="1" pictureRotation="0" itemRotation="0" anchorPoint="0" positionLock="false" file="" northOffset="0" svgBorderColor="0,0,0,255" uuid="{982bf0f3-407c-4126-a014-0d345a7427c4}" pictureHeight="14.1884" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties" type="Map">
       <Option name="dataDefinedSource" type="Map">
-       <Option value="true" name="active" type="bool"/>
-       <Option value="@cplus_setting_ci_logo" name="expression" type="QString"/>
-       <Option value="3" name="type" type="int"/>
+       <Option name="active" type="bool" value="true"/>
+       <Option name="expression" type="QString" value="@cplus_setting_ci_logo"/>
+       <Option name="type" type="int" value="3"/>
       </Option>
      </Option>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -1897,185 +1975,185 @@
    </customproperties>
   </LayoutObject>
  </LayoutItem>
- <LayoutItem labelText="The boundaries, names, and designations used in this report do [% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="3" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="accreditation_text_two" frame="false" opacity="1" size="167.683,15.4824,mm" positionOnPage="2.76111,277.998,mm" uuid="{596f2358-1511-459d-ad9c-38e765850775}" position="2.76111,584.998,mm" templateUuid="{596f2358-1511-459d-ad9c-38e765850775}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="3" size="167.683,15.4824,mm" referencePoint="0" id="accreditation_text_two" templateUuid="{07d7eebf-8352-4a65-9489-3f28a8fdefea}" positionOnPage="2.76111,277.998,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="The boundaries, names, and designations used in this report do [% @cplus_setting_disclaimer + ' This report is available under the terms of ' +  @cplus_setting_license + '.'%]" position="2.76111,584.998,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{07d7eebf-8352-4a65-9489-3f28a8fdefea}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="7.5" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="7.5" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem labelText="[% @layout_page %]" type="65641" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" marginX="0" zValue="2" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" halign="1" marginY="0" positionLock="false" valign="32" htmlState="0" id="page_number_two" frame="false" opacity="1" size="3.62469,4.75988,mm" positionOnPage="104.818,291.1,mm" uuid="{d02ea254-037f-48e2-8bc6-fd6393a30302}" position="104.818,598.1,mm" templateUuid="{d02ea254-037f-48e2-8bc6-fd6393a30302}" itemRotation="0" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="2" size="3.62469,4.75988,mm" referencePoint="0" id="page_number_two" templateUuid="{3bb70abe-780a-4fda-bb7a-7e5644491ab9}" positionOnPage="104.818,291.1,mm" background="false" frameJoinStyle="miter" type="65641" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" htmlState="0" marginX="0" valign="32" labelText="[% @layout_page %]" position="104.818,598.1,mm" visibility="1" itemRotation="0" marginY="0" positionLock="false" halign="1" uuid="{3bb70abe-780a-4fda-bb7a-7e5644491ab9}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="255,255,255,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="12" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+  <text-style fontUnderline="0" multilineHeight="1" textColor="255,255,255,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
    <families/>
-   <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-   <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-   <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-    <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+   <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+   <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+   <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+    <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
      <data_defined_properties>
       <Option type="Map">
-       <Option value="" name="name" type="QString"/>
+       <Option name="name" type="QString" value=""/>
        <Option name="properties"/>
-       <Option value="collection" name="type" type="QString"/>
+       <Option name="type" type="QString" value="collection"/>
       </Option>
      </data_defined_properties>
-     <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+     <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
       <Option type="Map">
-       <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-       <Option value="255,255,255,255" name="color" type="QString"/>
-       <Option value="bevel" name="joinstyle" type="QString"/>
-       <Option value="0,0" name="offset" type="QString"/>
-       <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-       <Option value="MM" name="offset_unit" type="QString"/>
-       <Option value="128,128,128,255" name="outline_color" type="QString"/>
-       <Option value="no" name="outline_style" type="QString"/>
-       <Option value="0" name="outline_width" type="QString"/>
-       <Option value="MM" name="outline_width_unit" type="QString"/>
-       <Option value="solid" name="style" type="QString"/>
+       <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="color" type="QString" value="255,255,255,255"/>
+       <Option name="joinstyle" type="QString" value="bevel"/>
+       <Option name="offset" type="QString" value="0,0"/>
+       <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+       <Option name="offset_unit" type="QString" value="MM"/>
+       <Option name="outline_color" type="QString" value="128,128,128,255"/>
+       <Option name="outline_style" type="QString" value="no"/>
+       <Option name="outline_width" type="QString" value="0"/>
+       <Option name="outline_width_unit" type="QString" value="MM"/>
+       <Option name="style" type="QString" value="solid"/>
       </Option>
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
      </layer>
     </symbol>
    </background>
-   <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+   <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
    <dd_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dd_properties>
   </text-style>
  </LayoutItem>
- <LayoutItem type="65643" frameJoinStyle="miter" visibility="1" blendMode="0" referencePoint="0" shapeType="1" zValue="1" excludeFromExports="0" background="false" outlineWidthM="0.3,mm" positionLock="false" id="footer_background_two" frame="false" opacity="1" size="210.362,22.6535,mm" positionOnPage="-0.36335,274.347,mm" uuid="{88b8b07d-fa2c-4eeb-8bbb-d424c63cb208}" position="-0.36335,581.347,mm" templateUuid="{88b8b07d-fa2c-4eeb-8bbb-d424c63cb208}" itemRotation="0" cornerRadiusMeasure="0,mm" groupUuid="">
-  <FrameColor alpha="255" red="0" green="0" blue="0"/>
-  <BackgroundColor alpha="255" red="255" green="255" blue="255"/>
+ <LayoutItem zValue="1" cornerRadiusMeasure="0,mm" size="210.362,22.6535,mm" shapeType="1" referencePoint="0" id="footer_background_two" templateUuid="{cc8328b8-6fda-4bb0-82a1-633c7c7d2fa2}" positionOnPage="-0.36335,274.347,mm" background="false" frameJoinStyle="miter" type="65643" groupUuid="" blendMode="0" outlineWidthM="0.3,mm" position="-0.36335,581.347,mm" visibility="1" itemRotation="0" positionLock="false" uuid="{cc8328b8-6fda-4bb0-82a1-633c7c7d2fa2}" opacity="1" frame="false" excludeFromExports="0">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
     <Option/>
    </customproperties>
   </LayoutObject>
-  <symbol alpha="1" frame_rate="10" force_rhr="0" name="" clip_to_extent="1" is_animated="0" type="fill">
+  <symbol name="" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
    <data_defined_properties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </data_defined_properties>
-   <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}">
+   <layer class="SimpleFill" pass="0" enabled="1" id="{25397022-0659-4e8f-a35c-a4d2d326e2b2}" locked="0">
     <Option type="Map">
-     <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-     <Option value="3,109,0,255" name="color" type="QString"/>
-     <Option value="miter" name="joinstyle" type="QString"/>
-     <Option value="0,0" name="offset" type="QString"/>
-     <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-     <Option value="MM" name="offset_unit" type="QString"/>
-     <Option value="0,0,0,255" name="outline_color" type="QString"/>
-     <Option value="no" name="outline_style" type="QString"/>
-     <Option value="0.3" name="outline_width" type="QString"/>
-     <Option value="MM" name="outline_width_unit" type="QString"/>
-     <Option value="solid" name="style" type="QString"/>
+     <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="color" type="QString" value="3,109,0,255"/>
+     <Option name="joinstyle" type="QString" value="miter"/>
+     <Option name="offset" type="QString" value="0,0"/>
+     <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+     <Option name="offset_unit" type="QString" value="MM"/>
+     <Option name="outline_color" type="QString" value="0,0,0,255"/>
+     <Option name="outline_style" type="QString" value="no"/>
+     <Option name="outline_width" type="QString" value="0.3"/>
+     <Option name="outline_width_unit" type="QString" value="MM"/>
+     <Option name="style" type="QString" value="solid"/>
     </Option>
     <data_defined_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </data_defined_properties>
    </layer>
   </symbol>
  </LayoutItem>
- <LayoutMultiFrame type="65652" gridStrokeWidth="0.1" includeHeader="0" verticalGrid="0" headerHAlignment="0" headerMode="2" cellMargin="0.9" resizeMode="0" backgroundColor="255,255,255,255" emptyTableMode="0" emptyTableMessage="" gridColor="0,0,0,255" showEmptyRows="0" uuid="{47e0f240-e3f6-482e-a4d9-0be0cb8b58ba}" templateUuid="{47e0f240-e3f6-482e-a4d9-0be0cb8b58ba}" horizontalGrid="1" wrapBehavior="0" showGrid="1">
-  <childFrame templateUuid="{a39f34e3-86ce-4103-966f-d187009a1806}" uuid="{a39f34e3-86ce-4103-966f-d187009a1806}"/>
+ <LayoutMultiFrame headerMode="2" horizontalGrid="1" wrapBehavior="0" resizeMode="0" showGrid="1" templateUuid="{fed81923-0826-48b4-900e-b8160395b5be}" includeHeader="0" gridStrokeWidth="0.1" emptyTableMode="0" type="65652" emptyTableMessage="" cellMargin="0.9" showEmptyRows="0" backgroundColor="255,255,255,255" headerHAlignment="0" verticalGrid="0" gridColor="0,0,0,255" uuid="{fed81923-0826-48b4-900e-b8160395b5be}">
+  <childFrame templateUuid="{1dae8448-722b-438b-8f7c-0c2078280f67}" uuid="{1dae8448-722b-438b-8f7c-0c2078280f67}"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -2083,304 +2161,304 @@
    </customproperties>
   </LayoutObject>
   <headerTextFormat>
-   <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="12" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="12" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
     <families/>
-    <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-    <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-    <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-        <Option value="255,255,255,255" name="color" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="128,128,128,255" name="outline_color" type="QString"/>
-        <Option value="no" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="solid" name="style" type="QString"/>
+        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="color" type="QString" value="255,255,255,255"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="128,128,128,255"/>
+        <Option name="outline_style" type="QString" value="no"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="style" type="QString" value="solid"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
     <dd_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dd_properties>
    </text-style>
   </headerTextFormat>
   <contentTextFormat>
-   <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="9" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="9" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
     <families/>
-    <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-    <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-    <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="0" name="angle" type="QString"/>
-        <Option value="square" name="cap_style" type="QString"/>
-        <Option value="255,158,23,255" name="color" type="QString"/>
-        <Option value="1" name="horizontal_anchor_point" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="circle" name="name" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="35,35,35,255" name="outline_color" type="QString"/>
-        <Option value="solid" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="diameter" name="scale_method" type="QString"/>
-        <Option value="2" name="size" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-        <Option value="MM" name="size_unit" type="QString"/>
-        <Option value="1" name="vertical_anchor_point" type="QString"/>
+        <Option name="angle" type="QString" value="0"/>
+        <Option name="cap_style" type="QString" value="square"/>
+        <Option name="color" type="QString" value="255,158,23,255"/>
+        <Option name="horizontal_anchor_point" type="QString" value="1"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="name" type="QString" value="circle"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="35,35,35,255"/>
+        <Option name="outline_style" type="QString" value="solid"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="scale_method" type="QString" value="diameter"/>
+        <Option name="size" type="QString" value="2"/>
+        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="size_unit" type="QString" value="MM"/>
+        <Option name="vertical_anchor_point" type="QString" value="1"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-        <Option value="255,255,255,255" name="color" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="128,128,128,255" name="outline_color" type="QString"/>
-        <Option value="no" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="solid" name="style" type="QString"/>
+        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="color" type="QString" value="255,255,255,255"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="128,128,128,255"/>
+        <Option name="outline_style" type="QString" value="no"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="style" type="QString" value="solid"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
     <dd_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dd_properties>
    </text-style>
   </contentTextFormat>
   <displayColumns>
-   <column attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <column heading="" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </column>
-   <column attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <column heading="" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </column>
   </displayColumns>
   <sortColumns/>
   <cellStyles>
-   <oddColumns cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <evenColumns cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <oddRows cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <evenRows cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <firstColumn cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <lastColumn cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <headerRow cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <firstRow cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <lastRow cellBackgroundColor="255,255,255,255" enabled="0"/>
+   <oddColumns enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <evenColumns enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <oddRows enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <evenRows enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <firstColumn enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <lastColumn enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <headerRow enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <firstRow enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <lastRow enabled="0" cellBackgroundColor="255,255,255,255"/>
   </cellStyles>
   <headers/>
   <contents>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Biodiversity" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Biodiversity"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="50%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Livelihoods" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="50%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="50%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Climate Resilience" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Livelihoods"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="100%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Ecological Infrastructure" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="0%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="50%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Policy" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Climate Resilience"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="0%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Finance- Years Experience" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="0%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="100%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Finance - Market Trends" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Ecological Infrastructure"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="0%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-   </row>
-   <row>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Finance - Net Present Value" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
-    </Option>
-    <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="0%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="0%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="Finance - Carbon" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Policy"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
-     <Option value="75%" name="content" type="QString"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="0%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Finance- Years Experience"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="0%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Finance - Market Trends"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="0%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Finance - Net Present Value"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="0%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+   </row>
+   <row>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="Finance - Carbon"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
+    </Option>
+    <Option type="Map">
+     <Option name="background" type="color" value=""/>
+     <Option name="content" type="QString" value="75%"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
   </contents>
@@ -2400,14 +2478,14 @@
    <column width="0"/>
   </columnWidths>
  </LayoutMultiFrame>
- <LayoutMultiFrame type="65652" gridStrokeWidth="0.1" includeHeader="1" verticalGrid="0" headerHAlignment="0" headerMode="1" cellMargin="1" resizeMode="0" backgroundColor="255,255,255,255" emptyTableMode="0" emptyTableMessage="" gridColor="0,0,0,255" showEmptyRows="0" uuid="{7fa4bd8a-8500-4631-b06d-a698c03a48e3}" templateUuid="{7fa4bd8a-8500-4631-b06d-a698c03a48e3}" horizontalGrid="1" wrapBehavior="0" showGrid="1">
-  <childFrame templateUuid="{7d4d4d5f-49b8-4e4e-8daf-33d26a01b50d}" uuid="{7d4d4d5f-49b8-4e4e-8daf-33d26a01b50d}"/>
+ <LayoutMultiFrame headerMode="1" horizontalGrid="1" wrapBehavior="0" resizeMode="0" showGrid="1" templateUuid="{c3df8176-117d-485c-abea-d8c2ae834b3a}" includeHeader="1" gridStrokeWidth="0.1" emptyTableMode="0" type="65652" emptyTableMessage="" cellMargin="1" showEmptyRows="0" backgroundColor="255,255,255,255" headerHAlignment="0" verticalGrid="0" gridColor="0,0,0,255" uuid="{c3df8176-117d-485c-abea-d8c2ae834b3a}">
+  <childFrame templateUuid="{23315901-e601-4914-a17b-da0615c317ad}" uuid="{23315901-e601-4914-a17b-da0615c317ad}"/>
   <LayoutObject>
    <dataDefinedProperties>
     <Option type="Map">
-     <Option value="" name="name" type="QString"/>
+     <Option name="name" type="QString" value=""/>
      <Option name="properties"/>
-     <Option value="collection" name="type" type="QString"/>
+     <Option name="type" type="QString" value="collection"/>
     </Option>
    </dataDefinedProperties>
    <customproperties>
@@ -2415,222 +2493,222 @@
    </customproperties>
   </LayoutObject>
   <headerTextFormat>
-   <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="11" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="11" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
     <families/>
-    <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-    <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-    <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="0" name="angle" type="QString"/>
-        <Option value="square" name="cap_style" type="QString"/>
-        <Option value="164,113,88,255" name="color" type="QString"/>
-        <Option value="1" name="horizontal_anchor_point" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="circle" name="name" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="35,35,35,255" name="outline_color" type="QString"/>
-        <Option value="solid" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="diameter" name="scale_method" type="QString"/>
-        <Option value="2" name="size" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-        <Option value="MM" name="size_unit" type="QString"/>
-        <Option value="1" name="vertical_anchor_point" type="QString"/>
+        <Option name="angle" type="QString" value="0"/>
+        <Option name="cap_style" type="QString" value="square"/>
+        <Option name="color" type="QString" value="164,113,88,255"/>
+        <Option name="horizontal_anchor_point" type="QString" value="1"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="name" type="QString" value="circle"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="35,35,35,255"/>
+        <Option name="outline_style" type="QString" value="solid"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="scale_method" type="QString" value="diameter"/>
+        <Option name="size" type="QString" value="2"/>
+        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="size_unit" type="QString" value="MM"/>
+        <Option name="vertical_anchor_point" type="QString" value="1"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-        <Option value="255,255,255,255" name="color" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="128,128,128,255" name="outline_color" type="QString"/>
-        <Option value="no" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="solid" name="style" type="QString"/>
+        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="color" type="QString" value="255,255,255,255"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="128,128,128,255"/>
+        <Option name="outline_style" type="QString" value="no"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="style" type="QString" value="solid"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
     <dd_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dd_properties>
    </text-style>
   </headerTextFormat>
   <contentTextFormat>
-   <text-style fontWordSpacing="0" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" fontSizeUnit="Point" namedStyle="Regular" fontLetterSpacing="0" multilineHeight="1" multilineHeightUnit="Percentage" capitalization="0" textColor="0,0,0,255" fontFamily="Ubuntu" fontKerning="1" previewBkgrdColor="255,255,255,255" fontUnderline="0" fontItalic="0" allowHtml="0" fontStrikeout="0" fontSize="9" forcedItalic="0" fontWeight="50" forcedBold="0" textOrientation="horizontal">
+   <text-style fontUnderline="0" multilineHeight="1" textColor="0,0,0,255" forcedBold="0" fontSizeUnit="Point" fontItalic="0" allowHtml="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1" textOpacity="1" fontWordSpacing="0" fontSize="9" fontFamily="Ubuntu" fontLetterSpacing="0" fontWeight="50" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" namedStyle="Regular" capitalization="0" multilineHeightUnit="Percentage" forcedItalic="0" fontStrikeout="0">
     <families/>
-    <text-buffer bufferOpacity="1" bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferDraw="0" bufferSizeUnits="MM" bufferJoinStyle="128" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255"/>
-    <text-mask maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskOpacity="1" maskType="0" maskEnabled="0" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-    <background shapeRadiiUnit="MM" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeBlendMode="0" shapeBorderWidth="0" shapeSVGFile="" shapeType="0" shapeSizeX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeDraw="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeJoinStyle="64" shapeOffsetY="0" shapeOffsetUnit="MM" shapeRadiiY="0" shapeRotationType="0" shapeSizeType="0" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBorderColor="128,128,128,255" shapeRotation="0" shapeSizeY="0">
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="markerSymbol" clip_to_extent="1" is_animated="0" type="marker">
+    <text-buffer bufferSize="1" bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferOpacity="1" bufferJoinStyle="128" bufferDraw="0" bufferBlendMode="0" bufferNoFill="1"/>
+    <text-mask maskType="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskJoinStyle="128"/>
+    <background shapeSizeUnit="MM" shapeType="0" shapeBlendMode="0" shapeJoinStyle="64" shapeOffsetY="0" shapeBorderWidth="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderColor="128,128,128,255" shapeOffsetUnit="MM" shapeRadiiY="0" shapeBorderWidthUnit="MM" shapeSizeType="0" shapeRadiiUnit="MM" shapeRotationType="0" shapeSizeX="0" shapeOffsetX="0" shapeSVGFile="" shapeOpacity="1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeRotation="0" shapeRadiiX="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0">
+     <symbol name="markerSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="marker" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleMarker" enabled="1" id="">
+      <layer class="SimpleMarker" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="0" name="angle" type="QString"/>
-        <Option value="square" name="cap_style" type="QString"/>
-        <Option value="133,182,111,255" name="color" type="QString"/>
-        <Option value="1" name="horizontal_anchor_point" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="circle" name="name" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="35,35,35,255" name="outline_color" type="QString"/>
-        <Option value="solid" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="diameter" name="scale_method" type="QString"/>
-        <Option value="2" name="size" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
-        <Option value="MM" name="size_unit" type="QString"/>
-        <Option value="1" name="vertical_anchor_point" type="QString"/>
+        <Option name="angle" type="QString" value="0"/>
+        <Option name="cap_style" type="QString" value="square"/>
+        <Option name="color" type="QString" value="133,182,111,255"/>
+        <Option name="horizontal_anchor_point" type="QString" value="1"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="name" type="QString" value="circle"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="35,35,35,255"/>
+        <Option name="outline_style" type="QString" value="solid"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="scale_method" type="QString" value="diameter"/>
+        <Option name="size" type="QString" value="2"/>
+        <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="size_unit" type="QString" value="MM"/>
+        <Option name="vertical_anchor_point" type="QString" value="1"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
-     <symbol alpha="1" frame_rate="10" force_rhr="0" name="fillSymbol" clip_to_extent="1" is_animated="0" type="fill">
+     <symbol name="fillSymbol" force_rhr="0" frame_rate="10" clip_to_extent="1" is_animated="0" type="fill" alpha="1">
       <data_defined_properties>
        <Option type="Map">
-        <Option value="" name="name" type="QString"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option value="collection" name="type" type="QString"/>
+        <Option name="type" type="QString" value="collection"/>
        </Option>
       </data_defined_properties>
-      <layer locked="0" pass="0" class="SimpleFill" enabled="1" id="">
+      <layer class="SimpleFill" pass="0" enabled="1" id="" locked="0">
        <Option type="Map">
-        <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
-        <Option value="255,255,255,255" name="color" type="QString"/>
-        <Option value="bevel" name="joinstyle" type="QString"/>
-        <Option value="0,0" name="offset" type="QString"/>
-        <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
-        <Option value="MM" name="offset_unit" type="QString"/>
-        <Option value="128,128,128,255" name="outline_color" type="QString"/>
-        <Option value="no" name="outline_style" type="QString"/>
-        <Option value="0" name="outline_width" type="QString"/>
-        <Option value="MM" name="outline_width_unit" type="QString"/>
-        <Option value="solid" name="style" type="QString"/>
+        <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="color" type="QString" value="255,255,255,255"/>
+        <Option name="joinstyle" type="QString" value="bevel"/>
+        <Option name="offset" type="QString" value="0,0"/>
+        <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+        <Option name="offset_unit" type="QString" value="MM"/>
+        <Option name="outline_color" type="QString" value="128,128,128,255"/>
+        <Option name="outline_style" type="QString" value="no"/>
+        <Option name="outline_width" type="QString" value="0"/>
+        <Option name="outline_width_unit" type="QString" value="MM"/>
+        <Option name="style" type="QString" value="solid"/>
        </Option>
        <data_defined_properties>
         <Option type="Map">
-         <Option value="" name="name" type="QString"/>
+         <Option name="name" type="QString" value=""/>
          <Option name="properties"/>
-         <Option value="collection" name="type" type="QString"/>
+         <Option name="type" type="QString" value="collection"/>
         </Option>
        </data_defined_properties>
       </layer>
      </symbol>
     </background>
-    <shadow shadowOffsetUnit="MM" shadowDraw="0" shadowOffsetDist="1" shadowRadius="1.5" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowUnder="0" shadowOffsetAngle="135"/>
+    <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5" shadowUnder="0" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowColor="0,0,0,255" shadowBlendMode="6" shadowRadiusAlphaOnly="0" shadowScale="100"/>
     <dd_properties>
      <Option type="Map">
-      <Option value="" name="name" type="QString"/>
+      <Option name="name" type="QString" value=""/>
       <Option name="properties"/>
-      <Option value="collection" name="type" type="QString"/>
+      <Option name="type" type="QString" value="collection"/>
      </Option>
     </dd_properties>
    </text-style>
   </contentTextFormat>
   <displayColumns>
-   <column attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="Implementation Model" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <column heading="Implementation Model" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </column>
-   <column attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="Area (ha)" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <column heading="Area (ha)" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </column>
   </displayColumns>
   <sortColumns/>
   <cellStyles>
-   <oddColumns cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <evenColumns cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <oddRows cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <evenRows cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <firstColumn cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <lastColumn cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <headerRow cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <firstRow cellBackgroundColor="255,255,255,255" enabled="0"/>
-   <lastRow cellBackgroundColor="255,255,255,255" enabled="0"/>
+   <oddColumns enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <evenColumns enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <oddRows enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <evenRows enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <firstColumn enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <lastColumn enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <headerRow enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <firstRow enabled="0" cellBackgroundColor="255,255,255,255"/>
+   <lastRow enabled="0" cellBackgroundColor="255,255,255,255"/>
   </cellStyles>
   <headers>
-   <header attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="Implementation Model" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <header heading="Implementation Model" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </header>
-   <header attribute="" sortByRank="0" width="0" vAlignment="128" hAlignment="1" heading="Area (ha)" sortOrder="0">
-    <backgroundColor alpha="0" red="0" green="0" blue="0"/>
+   <header heading="Area (ha)" sortOrder="0" vAlignment="128" sortByRank="0" hAlignment="1" width="0" attribute="">
+    <backgroundColor red="0" green="0" blue="0" alpha="0"/>
    </header>
   </headers>
   <contents>
    <row>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
+     <Option name="background" type="color" value=""/>
      <Option name="content" type="invalid"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
     <Option type="Map">
-     <Option value="" name="background" type="color"/>
+     <Option name="background" type="color" value=""/>
      <Option name="content" type="invalid"/>
-     <Option value="" name="foreground" type="color"/>
-     <Option value="1" name="halign" type="int"/>
-     <Option value="128" name="valign" type="int"/>
+     <Option name="foreground" type="color" value=""/>
+     <Option name="halign" type="int" value="1"/>
+     <Option name="valign" type="int" value="128"/>
     </Option>
    </row>
   </contents>
@@ -2644,48 +2722,48 @@
  </LayoutMultiFrame>
  <customproperties>
   <Option type="Map">
-   <Option value="png" name="atlasRasterFormat" type="QString"/>
-   <Option value="0" name="forceVector" type="int"/>
-   <Option value="1" name="pdfAppendGeoreference" type="int"/>
-   <Option value="0" name="pdfCreateGeoPdf" type="int"/>
-   <Option value="0" name="pdfDisableRasterTiles" type="int"/>
-   <Option value="" name="pdfExportThemes" type="QString"/>
-   <Option value="1" name="pdfIncludeMetadata" type="int"/>
-   <Option value="Final_Highest_Position_Carbon_0e7be90c_db93_4b7b_b9be_c11aa38ab4c1~~~social_int_clip_norm_inverse_e2de5f1a_aa21_4c94_aa2d_6196dac6aff0~~~social_int_clip_norm_a4374b7b_741d_4270_9e2b_d27320de59c4~~~Policy_b44fa87c_4711_4dde_b139_3d8e91767ddc~~~ei_all_gknp_clip_norm_inverse_ca6afb6d_ec6b_441b_a751_3dd0fdaff13d~~~ei_all_gknp_clip_norm_2310282e_df57_4cb2_999f_25c2751a08d5~~~cccombo_clip_norm_inverse_3d4977d0_97c3_44f1_b8bc_3fb62eda96ec~~~cccombo_clip_norm_3b275553_b29f_4f39_941f_ee136d826c05~~~biocombine_clip_norm_inverse_fc876422_7ac0_40ff_a094_ff41c51cb918~~~biocombine_clip_norm_d7722cb5_4adf_4f3a_86b5_72c4790eeca6~~~Final_Alien_Plant_Removal_f4d0b80b_e589_4422_8a02_4cc1b7b0f0c0~~~Final_Assisted_Nat_Regen_556819d3_06df_4d63_bf11_1b4fff3c0b2d~~~Final_Bush_Thinning_d5284c1f_c2eb_4c52_bd0f_27eb60319e59~~~Final_Eat_Fresh_1d7180a9_5c09_4c95_8a51_9bd29b569e98~~~Final_Herding_4_Health_e329e016_667c_410f_99b4_36a37226904f~~~Final_Wattle_Naturally_d729d8a8_0a0e_49d4_8d20_33165713cb23~~~Woody_Encroachment_norm_6da710af_b9a3_48f5_ac08_634f30d21ab3~~~Restoration_Wetland_carbon_norm_5cbc6509_5c6b_4fec_ad84_7e4c408a1faf~~~Restoration_Savanna_carbon_norm_6f983163_023e_4233_902a_819e327f7321~~~Restoration_Forest_carbon_norm_f1d45658_f78c_4b3c_96b6_8f1052314846~~~Fire_Management_Krugerhalf_carbon_norm_895ba558_c8d2_40db_8a10_7a1781c6a5d0~~~Avoided_Wetland_carbon_norm_b1ffda03_6692_4e6c_87d4_5a881732f0e1~~~Avoided_OpenWoodland_NaturalWoodedLand_carbon_norm_2efdcdd6_eebf_46bd_a30f_01de841c105c~~~Avoided_Grassland_carbon_norm_246e0f70_8465_4c60_aaae_7786e19dab54~~~Avoided_Forest_carbon_norm_46c2da65_20a7_4bce_8681_d219ec782fcf~~~Animal_Management_carbon_norm_21d7d1ea_f528_4a50_9a4e_af40e33fd8d7~~~Agroforestry_carbon_norm_f5034c21_96ef_446b_99e4_7443f34ff419" name="pdfLayerOrder" type="QString"/>
-   <Option value="0" name="pdfLosslessImages" type="int"/>
-   <Option value="0" name="pdfOgcBestPracticeFormat" type="int"/>
-   <Option value="1" name="pdfSimplify" type="int"/>
-   <Option value="0" name="pdfTextFormat" type="int"/>
-   <Option value="true" name="singleFile" type="bool"/>
+   <Option name="atlasRasterFormat" type="QString" value="png"/>
+   <Option name="forceVector" type="int" value="0"/>
+   <Option name="pdfAppendGeoreference" type="int" value="1"/>
+   <Option name="pdfCreateGeoPdf" type="int" value="0"/>
+   <Option name="pdfDisableRasterTiles" type="int" value="0"/>
+   <Option name="pdfExportThemes" type="QString" value=""/>
+   <Option name="pdfIncludeMetadata" type="int" value="1"/>
+   <Option name="pdfLayerOrder" type="QString" value="Final_Highest_Position_Carbon_0e7be90c_db93_4b7b_b9be_c11aa38ab4c1~~~social_int_clip_norm_inverse_e2de5f1a_aa21_4c94_aa2d_6196dac6aff0~~~social_int_clip_norm_a4374b7b_741d_4270_9e2b_d27320de59c4~~~Policy_b44fa87c_4711_4dde_b139_3d8e91767ddc~~~ei_all_gknp_clip_norm_inverse_ca6afb6d_ec6b_441b_a751_3dd0fdaff13d~~~ei_all_gknp_clip_norm_2310282e_df57_4cb2_999f_25c2751a08d5~~~cccombo_clip_norm_inverse_3d4977d0_97c3_44f1_b8bc_3fb62eda96ec~~~cccombo_clip_norm_3b275553_b29f_4f39_941f_ee136d826c05~~~biocombine_clip_norm_inverse_fc876422_7ac0_40ff_a094_ff41c51cb918~~~biocombine_clip_norm_d7722cb5_4adf_4f3a_86b5_72c4790eeca6~~~Final_Alien_Plant_Removal_f4d0b80b_e589_4422_8a02_4cc1b7b0f0c0~~~Final_Assisted_Nat_Regen_556819d3_06df_4d63_bf11_1b4fff3c0b2d~~~Final_Bush_Thinning_d5284c1f_c2eb_4c52_bd0f_27eb60319e59~~~Final_Eat_Fresh_1d7180a9_5c09_4c95_8a51_9bd29b569e98~~~Final_Herding_4_Health_e329e016_667c_410f_99b4_36a37226904f~~~Final_Wattle_Naturally_d729d8a8_0a0e_49d4_8d20_33165713cb23~~~Woody_Encroachment_norm_6da710af_b9a3_48f5_ac08_634f30d21ab3~~~Restoration_Wetland_carbon_norm_5cbc6509_5c6b_4fec_ad84_7e4c408a1faf~~~Restoration_Savanna_carbon_norm_6f983163_023e_4233_902a_819e327f7321~~~Restoration_Forest_carbon_norm_f1d45658_f78c_4b3c_96b6_8f1052314846~~~Fire_Management_Krugerhalf_carbon_norm_895ba558_c8d2_40db_8a10_7a1781c6a5d0~~~Avoided_Wetland_carbon_norm_b1ffda03_6692_4e6c_87d4_5a881732f0e1~~~Avoided_OpenWoodland_NaturalWoodedLand_carbon_norm_2efdcdd6_eebf_46bd_a30f_01de841c105c~~~Avoided_Grassland_carbon_norm_246e0f70_8465_4c60_aaae_7786e19dab54~~~Avoided_Forest_carbon_norm_46c2da65_20a7_4bce_8681_d219ec782fcf~~~Animal_Management_carbon_norm_21d7d1ea_f528_4a50_9a4e_af40e33fd8d7~~~Agroforestry_carbon_norm_f5034c21_96ef_446b_99e4_7443f34ff419"/>
+   <Option name="pdfLosslessImages" type="int" value="0"/>
+   <Option name="pdfOgcBestPracticeFormat" type="int" value="0"/>
+   <Option name="pdfSimplify" type="int" value="1"/>
+   <Option name="pdfTextFormat" type="int" value="0"/>
+   <Option name="singleFile" type="bool" value="true"/>
    <Option name="variableNames" type="List">
-    <Option value="cplus_setting_organization" type="QString"/>
-    <Option value="cplus_setting_email" type="QString"/>
-    <Option value="cplus_setting_website" type="QString"/>
-    <Option value="cplus_setting_custom_logo" type="QString"/>
-    <Option value="cplus_setting_cplus_logo" type="QString"/>
-    <Option value="cplus_setting_ci_logo" type="QString"/>
-    <Option value="cplus_setting_footer" type="QString"/>
-    <Option value="cplus_setting_disclaimer" type="QString"/>
-    <Option value="cplus_setting_license" type="QString"/>
-    <Option value="cplus_setting_base_dir" type="QString"/>
-    <Option value="cplus_model_scenario_name" type="QString"/>
-    <Option value="cplus_model_scenario_description" type="QString"/>
+    <Option type="QString" value="cplus_setting_organization"/>
+    <Option type="QString" value="cplus_setting_email"/>
+    <Option type="QString" value="cplus_setting_website"/>
+    <Option type="QString" value="cplus_setting_custom_logo"/>
+    <Option type="QString" value="cplus_setting_cplus_logo"/>
+    <Option type="QString" value="cplus_setting_ci_logo"/>
+    <Option type="QString" value="cplus_setting_footer"/>
+    <Option type="QString" value="cplus_setting_disclaimer"/>
+    <Option type="QString" value="cplus_setting_license"/>
+    <Option type="QString" value="cplus_setting_base_dir"/>
+    <Option type="QString" value="cplus_model_scenario_name"/>
+    <Option type="QString" value="cplus_model_scenario_description"/>
    </Option>
    <Option name="variableValues" type="List">
-    <Option value="" type="QString"/>
-    <Option value="" type="QString"/>
-    <Option value="" type="QString"/>
-    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin/logos/ci_logo.png" type="QString"/>
-    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\cplus_logo.svg" type="QString"/>
-    <Option value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\ci_logo.svg" type="QString"/>
-    <Option value="" type="QString"/>
-    <Option value="The boundaries, names, and designations used in this report do not imply official endorsement or acceptance by Conservation International Foundation, or its partner organizations and contributors." type="QString"/>
-    <Option value="Creative Commons Attribution 4.0 International License (CC BY 4.0)" type="QString"/>
-    <Option value="D:\Frank\Kartoza\Data\cplus\Temp" type="QString"/>
-    <Option value="Scenario name will be inserted here" type="QString"/>
-    <Option value="Scenario description will be inserted here" type="QString"/>
+    <Option type="QString" value=""/>
+    <Option type="QString" value=""/>
+    <Option type="QString" value=""/>
+    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin/logos/ci_logo.png"/>
+    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\cplus_logo.svg"/>
+    <Option type="QString" value="C:\Users\Kahiu\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\cplus_plugin\logos\ci_logo.svg"/>
+    <Option type="QString" value=""/>
+    <Option type="QString" value="The boundaries, names, and designations used in this report do not imply official endorsement or acceptance by Conservation International Foundation, or its partner organizations and contributors."/>
+    <Option type="QString" value="Creative Commons Attribution 4.0 International License (CC BY 4.0)"/>
+    <Option type="QString" value="D:\Frank\Kartoza\Data\cplus\Temp"/>
+    <Option type="QString" value="Scenario name will be inserted here"/>
+    <Option type="QString" value="Scenario description will be inserted here"/>
    </Option>
   </Option>
  </customproperties>
- <Atlas pageNameExpression="&quot;NAME&quot;" filterFeatures="0" sortFeatures="0" enabled="0" coverageLayer="" hideCoverage="0" filenamePattern="'output_'||@atlas_featurenumber"/>
+ <Atlas hideCoverage="0" filterFeatures="0" filenamePattern="'output_'||@atlas_featurenumber" enabled="0" coverageLayer="" sortFeatures="0" pageNameExpression="&quot;NAME&quot;"/>
 </Layout>

--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -902,3 +902,20 @@ DEFAULT_REPORT_DISCLAIMER = (
 DEFAULT_REPORT_LICENSE = (
     "Creative Commons Attribution 4.0 International " "License (CC BY 4.0)"
 )
+
+# KEY: Implementation model identifier, VALUE: pixel value
+DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES = {
+    "a0b8fd2d-1259-4141-9ad6-d4369cf0dfd4": 1,
+    "1c8db48b-717b-451b-a644-3af1bee984ea": 2,
+    "de9597b2-f082-4299-9620-1da3bad8ab62": 3,
+    "40f04ea6-1f91-4695-830a-7d46f821f5db": 4,
+    "43f96ed8-cd2f-4b91-b6c8-330d3b93bcc1": 5,
+    "c3c5a381-2b9f-4ddc-8a77-708239314fb6": 6,
+    "3defbd0e-2b12-4ab2-a7d4-a035152396a7": 7,
+    "22f9e555-0356-4b18-b292-c2d516dcdba5": 8,
+    "177f1f27-cace-4f3e-9c3c-ef2cf54fc283": 9,
+    "4fbfcb1c-bfd7-4305-b216-7a1077a2ccf7": 10,
+    "d9d00a77-3db1-4390-944e-09b27bcbb981": 11,
+    "20491092-e665-4ee7-b92f-b0ed864c7312": 12,
+    "92054916-e8ea-45a0-992c-b6273d1b75a7": 13,
+}

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1928,7 +1928,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         self.reset_reporting_feedback()
 
-        submit_result = self.report_manager.generate(self.scenario_result, self.reporting_feedback)
+        submit_result = self.report_manager.generate(
+            self.scenario_result, self.reporting_feedback
+        )
         if not submit_result.status:
             msg = self.tr("Unable to submit report request for scenario")
             self.show_message(f"{msg} {self.scenario_result.scenario.name}.")

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -139,9 +139,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         self.analysis_finished.connect(self.post_analysis)
 
         # Report manager
-        self.rpm = report_manager
-        self.rpm.generate_started.connect(self.on_report_running)
-        self.rpm.generate_completed.connect(self.on_report_finished)
+        self.report_manager = report_manager
+        self.report_manager.generate_started.connect(self.on_report_running)
+        self.report_manager.generate_completed.connect(self.on_report_finished)
         self.reporting_feedback: typing.Union[QgsFeedback, None] = None
 
     def prepare_input(self):
@@ -1928,7 +1928,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         self.reset_reporting_feedback()
 
-        submit_result = self.rpm.generate(self.scenario_result, self.reporting_feedback)
+        submit_result = self.report_manager.generate(self.scenario_result, self.reporting_feedback)
         if not submit_result.status:
             msg = self.tr("Unable to submit report request for scenario")
             self.show_message(f"{msg} {self.scenario_result.scenario.name}.")

--- a/src/cplus_plugin/lib/reports/generator.py
+++ b/src/cplus_plugin/lib/reports/generator.py
@@ -2,6 +2,7 @@
 """
 CPLUS Report generator.
 """
+from numbers import Number
 import os
 from pathlib import Path
 import traceback
@@ -24,11 +25,14 @@ from qgis.core import (
     QgsLayoutItemShape,
     QgsLayoutPoint,
     QgsLayoutSize,
+    QgsMapLayerLegendUtils,
     QgsPrintLayout,
+    QgsProcessingFeedback,
     QgsProject,
     QgsRasterLayer,
     QgsReadWriteContext,
     QgsScaleBarSettings,
+    QgsSimpleLegendNode,
     QgsTask,
     QgsTableCell,
     QgsTextFormat,
@@ -40,14 +44,15 @@ from qgis.PyQt import QtCore, QtGui, QtXml
 
 from ...definitions.constants import IM_GROUP_LAYER_NAME
 from ...definitions.defaults import (
+    DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES,
     IMPLEMENTATION_MODEL_AREA_TABLE_ID,
     MINIMUM_ITEM_HEIGHT,
     MINIMUM_ITEM_WIDTH,
-    PRIORITY_GROUP_WEIGHT_TABLE_ID,
-    SCENARIO_OUTPUT_LAYER_NAME,
+    PRIORITY_GROUP_WEIGHT_TABLE_ID
 )
 from .layout_items import CplusMapRepeatItem
 from ...models.base import ImplementationModel
+from ...models.helpers import extent_to_project_crs_extent
 from ...models.report import ReportContext, ReportResult
 from ...utils import (
     calculate_raster_value_area,
@@ -66,8 +71,8 @@ class ReportGeneratorTask(QgsTask):
         self._context = context
         self._result = None
         self._generator = ReportGenerator(self._context, self._context.feedback)
-        self.lm = QgsProject.instance().layoutManager()
-        self.lm.layoutAdded.connect(self._on_layout_added)
+        self.layout_manager = QgsProject.instance().layoutManager()
+        self.layout_manager.layoutAdded.connect(self._on_layout_added)
 
     @property
     def context(self) -> ReportContext:
@@ -118,19 +123,23 @@ class ReportGeneratorTask(QgsTask):
 
         return self._result.success
 
-    @classmethod
-    def _zoom_map_items_to_current_extents(cls, layout: QgsPrintLayout):
+    def _zoom_map_items_to_current_extents(self, layout: QgsPrintLayout):
         """Zoom extents of map items in the layout to current map canvas
         extents.
         """
-        extent = iface.mapCanvas().mapSettings().visibleExtent()
+        scenario_extent = extent_to_project_crs_extent(
+            self._context.scenario.extent, QgsProject.instance()
+        )
+        if scenario_extent is None:
+            log("Cannot set extents for map items in the report.")
+            return
+
         for item in layout.items():
             if isinstance(item, QgsLayoutItemMap):
-                item.zoomToExtent(extent)
+                item.zoomToExtent(scenario_extent)
 
     def _on_layout_added(self, name: str):
         """Slot raised when a layout has been added to the manager."""
-        # self._generator.export_to_pdf()
         self._export_to_pdf()
 
     def _export_to_pdf(self):
@@ -140,12 +149,21 @@ class ReportGeneratorTask(QgsTask):
         # We fetch the layout afresh so that the PDF export can contain
         # synced extents.
         layout_name = self._generator.layout.name()
-        layout = self.lm.layoutByName(layout_name)
+        layout = self.layout_manager.layoutByName(layout_name)
         if layout is None:
             log(
                 f"Could not find {layout_name} layout for exporting to PDF.", info=False
             )
             return
+
+        # Set project metadata which will be cascaded to the PDF document
+        project = QgsProject.instance()
+        metadata = project.metadata()
+        metadata.setTitle(self._context.scenario.name)
+        metadata.setAuthor("CPLUS plugin")
+        metadata.setAbstract(self._context.scenario.description)
+        metadata.setCreationDateTime(QtCore.QDateTime.currentDateTime())
+        project.setMetadata(metadata)
 
         exporter = QgsLayoutExporter(layout)
         pdf_path = f"{self._generator.output_dir}/{layout_name}.pdf"
@@ -214,6 +232,11 @@ class ReportGenerator:
         self._repeat_page_num = -1
         self._repeat_item = None
         self._reference_layer_group = None
+        self._scenario_layer = None
+        self._area_processing_feedback = None
+
+        if self._feedback:
+            self._feedback.canceled.connect(self._on_feedback_cancelled)
 
     @property
     def context(self) -> ReportContext:
@@ -272,6 +295,24 @@ class ReportGenerator:
         """
         return self._repeat_page
 
+    def _reset_area_processing_feedback(self):
+        """Creates a new instance of processing feedback."""
+        if self._area_processing_feedback is not None:
+            self._area_processing_feedback.progressChanged.disconnect()
+
+        self._area_processing_feedback = QgsProcessingFeedback()
+        self._area_processing_feedback.progressChanged.connect(
+            self._on_area_progress_changed
+        )
+
+    def _on_area_progress_changed(self, progress: float):
+        """Slot raised when progress for area calculation."""
+        # Check cancel or update progress
+        total_progress = self._area_calculation_progress_reference + (
+            self._area_calculation_progress_reference / 100 * progress
+        )
+        self._process_check_cancelled_or_set_progress(total_progress)
+
     def _process_check_cancelled_or_set_progress(self, value: float) -> bool:
         """Check if there is a request to cancel the process
         if a feedback object had been specified.
@@ -285,6 +326,15 @@ class ReportGenerator:
             self._feedback.setProgress(value)
 
         return False
+
+    def _on_feedback_cancelled(self):
+        # Slot raised when the main feedback object has been cancelled.
+        # Cancel area calculation as well
+        if (
+            self._area_processing_feedback
+            and not self._area_processing_feedback.isCanceled()
+        ):
+            self._area_processing_feedback.cancel()
 
     def _set_project(self):
         """Deserialize the project from the report context."""
@@ -314,14 +364,6 @@ class ReportGenerator:
             self._error_messages.append(f"{tr_msg} {self._context.project_file}.")
             return
 
-        # Set project metadata which will be cascaded to the PDF document
-        metadata = project.metadata()
-        metadata.setTitle(self._context.scenario.name)
-        metadata.setAuthor("CPLUS plugin")
-        metadata.setAbstract(self._context.scenario.description)
-        metadata.setCreationDateTime(QtCore.QDateTime.currentDateTime())
-        project.setMetadata(metadata)
-
         # Set reference layer group in project i.e. the one that contains
         # the scenario output layer.
         layer_root = project.layerTreeRoot()
@@ -332,6 +374,7 @@ class ReportGenerator:
         ]
         if len(matching_tree_layers) > 0:
             scenario_tree_layer = matching_tree_layers[0]
+            self._scenario_layer = scenario_tree_layer.layer()
             parent = scenario_tree_layer.parent()
             if parent.nodeType() == QgsLayerTreeNode.NodeType.NodeGroup:
                 self._reference_layer_group = parent
@@ -504,7 +547,6 @@ class ReportGenerator:
 
         max_items_page = num_rows * num_cols
 
-        # Temporary for testing
         num_implementation_models = len(self._context.scenario.models)
 
         if num_implementation_models == 0:
@@ -846,12 +888,34 @@ class ReportGenerator:
             self._error_messages.append(tr_msg)
             return
 
+        legend_item.setAutoUpdateModel(False)
         model = legend_item.model()
-        root_node = model.rootGroup()
-        for tree_layer in root_node.findLayers():
-            if tree_layer.name().startswith(SCENARIO_OUTPUT_LAYER_NAME):
-                tree_layer.setName(tr("Ideal Landuse"))
+        for tree_layer in legend_item.model().rootGroup().findLayers():
+            if tree_layer.name() == self._context.output_layer_name:
+                # We need to refresh the tree layer for the nodes to be loaded
                 model.refreshLayerLegend(tree_layer)
+                scenario_child_nodes = model.layerLegendNodes(tree_layer)
+                for i, child_node in enumerate(scenario_child_nodes):
+                    # Find node containing "Band 1..." and remove it
+                    # i.e. exclude it from the tree layer.
+                    if isinstance(child_node, QgsSimpleLegendNode):
+                        indexes = list(range(i + 1, len(scenario_child_nodes)))
+                        QgsMapLayerLegendUtils.setLegendNodeOrder(tree_layer, indexes)
+
+                # Rename layer name in the legend
+                tree_layer.setCustomProperty("legend/title-label", tr("Ideal Landuse"))
+                model.refreshLayerLegend(tree_layer)
+            else:
+                # Remove all other non-scenario layers
+                node_index = model.node2index(tree_layer)
+                if not node_index.isValid():
+                    continue
+                model.removeRow(node_index.row(), node_index.parent())
+
+        # Refresh legend
+        legend_item.adjustBoxSize()
+        legend_item.invalidateCache()
+        legend_item.update()
 
     def _get_table_from_id(
         self, table_id: str
@@ -877,35 +941,51 @@ class ReportGenerator:
 
         num_implementation_models = len(self._context.scenario.models)
         if num_implementation_models == 0:
-            tr_msg = "No implementation models in the scenario"
+            tr_msg = tr("No implementation models in the scenario.")
             self._error_messages.append(tr_msg)
             return
 
-        progress_percent_per_im = 40 / num_implementation_models
+        if self._scenario_layer is None:
+            tr_msg = tr("Scenario layer could not be set to calculate the area.")
+            self._error_messages.append(tr_msg)
+            return
+
+        self._reset_area_processing_feedback()
+
+        # Calculate pixel area
+        pixel_area_info = calculate_raster_value_area(
+            self._scenario_layer, feedback=self._area_processing_feedback
+        )
+        if len(pixel_area_info) == 0:
+            tr_msg = tr("No implementation model areas from the calculation.")
+            self._error_messages.append(tr_msg)
+            return
 
         rows_data = []
         for imp_model in self._context.scenario.models:
+            # IM name
             name_cell = QgsTableCell(imp_model.name)
             name_cell.setBackgroundColor(QtGui.QColor("#e9e9e9"))
-            layer = QgsRasterLayer(imp_model.path, imp_model.name)
-            if layer is None:
-                area_info = tr("No area <Error in layer>")
-            else:
-                area_info = calculate_raster_value_area(layer)
-                if area_info == -1:
-                    area_info = tr("An error occurred when computing the area.")
-            area_cell = QgsTableCell(area_info)
-            number_format = QgsBasicNumericFormat()
-            number_format.setThousandsSeparator(",")
-            number_format.setNumberDecimalPlaces(2)
-            area_cell.setNumericFormat(number_format)
-            rows_data.append([name_cell, area_cell])
 
-            # Check cancel or update progress
-            if self._feedback:
-                progress = self._feedback.progress() + progress_percent_per_im
-                if self._process_check_cancelled_or_set_progress(progress):
-                    break
+            # IM area
+            im_uuid = str(imp_model.uuid)
+            if im_uuid in DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES:
+                im_pixel_value = DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES[im_uuid]
+                area_info = pixel_area_info.get(im_pixel_value, None)
+                if area_info is None:
+                    area_info = "0"
+            else:
+                area_info = tr("<Pixel value not found>")
+
+            area_cell = QgsTableCell(area_info)
+            if isinstance(area_info, Number):
+                number_format = QgsBasicNumericFormat()
+                number_format.setThousandsSeparator(",")
+                number_format.setShowTrailingZeros(True)
+                number_format.setNumberDecimalPlaces(2)
+                area_cell.setNumericFormat(number_format)
+
+            rows_data.append([name_cell, area_cell])
 
         parent_table.setTableContents(rows_data)
 
@@ -918,13 +998,30 @@ class ReportGenerator:
             return
 
         rows_data = []
+        groups = []
         for priority_group in self._context.scenario.priority_layer_groups:
-            for priority_layer in priority_group:
-                if "name" not in priority_layer or "value" not in priority_layer:
-                    continue
-                name_cell = QgsTableCell(priority_layer["name"])
-                value_cell = QgsTableCell(priority_layer["value"])
-                rows_data.append([name_cell, value_cell])
+            if "name" not in priority_group or "value" not in priority_group:
+                continue
+
+            group_name = priority_group["name"]
+            # Ensure there are no duplicates in the table
+            if group_name in groups:
+                continue
+
+            # If value is less than or equal to zero then do not include in the table.
+            value = -1
+            try:
+                value = int(priority_group["value"])
+            except ValueError:
+                continue
+
+            if value <= 0:
+                continue
+
+            name_cell = QgsTableCell(group_name)
+            value_cell = QgsTableCell(value)
+            rows_data.append([name_cell, value_cell])
+            groups.append(group_name)
 
         parent_table.setTableContents(rows_data)
 

--- a/src/cplus_plugin/lib/reports/generator.py
+++ b/src/cplus_plugin/lib/reports/generator.py
@@ -48,7 +48,7 @@ from ...definitions.defaults import (
     IMPLEMENTATION_MODEL_AREA_TABLE_ID,
     MINIMUM_ITEM_HEIGHT,
     MINIMUM_ITEM_WIDTH,
-    PRIORITY_GROUP_WEIGHT_TABLE_ID
+    PRIORITY_GROUP_WEIGHT_TABLE_ID,
 )
 from .layout_items import CplusMapRepeatItem
 from ...models.base import ImplementationModel

--- a/src/cplus_plugin/lib/reports/manager.py
+++ b/src/cplus_plugin/lib/reports/manager.py
@@ -21,10 +21,7 @@ from qgis.PyQt import QtCore, QtGui
 
 from ...conf import settings_manager, Settings
 from ...definitions.constants import OUTPUTS_SEGMENT
-from ...models.base import (
-    Scenario,
-    ScenarioResult
-)
+from ...models.base import Scenario, ScenarioResult
 from ...models.report import ReportContext, ReportResult, ReportSubmitStatus
 from ...utils import FileUtils, log, tr
 

--- a/src/cplus_plugin/lib/reports/manager.py
+++ b/src/cplus_plugin/lib/reports/manager.py
@@ -6,7 +6,6 @@ and handles report generation.
 import os
 from pathlib import Path
 import typing
-import uuid
 
 from qgis.core import (
     Qgis,
@@ -23,12 +22,8 @@ from qgis.PyQt import QtCore, QtGui
 from ...conf import settings_manager, Settings
 from ...definitions.constants import OUTPUTS_SEGMENT
 from ...models.base import (
-    ImplementationModel,
-    LayerType,
-    NcsPathway,
     Scenario,
-    ScenarioResult,
-    SpatialExtent,
+    ScenarioResult
 )
 from ...models.report import ReportContext, ReportResult, ReportSubmitStatus
 from ...utils import FileUtils, log, tr
@@ -56,8 +51,8 @@ class ReportManager(QtCore.QObject):
         # Report results (value) indexed by scenario id (key)
         self._report_results = {}
 
-        self.tm = QgsApplication.instance().taskManager()
-        self.tm.statusChanged.connect(self.on_task_status_changed)
+        self.task_manager = QgsApplication.instance().taskManager()
+        self.task_manager.statusChanged.connect(self.on_task_status_changed)
 
         self.root_output_dir = ""
         self._set_root_output_dir()
@@ -133,7 +128,7 @@ class ReportManager(QtCore.QObject):
 
         elif status == QgsTask.TaskStatus.Complete:
             # Get result
-            task = self.tm.task(task_id)
+            task = self.task_manager.task(task_id)
             result = task.result
             if result is not None:
                 self._report_results[scenario_id] = result
@@ -159,7 +154,7 @@ class ReportManager(QtCore.QObject):
             return False
 
         task_id = self._report_tasks[scenario_id]
-        task = self.tm.task(task_id)
+        task = self.task_manager.task(task_id)
         if task is None:
             return False
 
@@ -189,10 +184,6 @@ class ReportManager(QtCore.QObject):
         """
         if not self.root_output_dir:
             return ""
-
-        # if not os.access(self.root_output_dir, os.W_OK):
-        #     log("No permission to write to output directory.")
-        #     return ""
 
         output_path = Path(self.root_output_dir)
         if not output_path.exists():
@@ -262,7 +253,7 @@ class ReportManager(QtCore.QObject):
         msg_tr = tr("Generating report for")
         description = f"{msg_tr} {ctx.scenario.name}"
         report_task = ReportGeneratorTask(description, ctx)
-        task_id = self.tm.addTask(report_task)
+        task_id = self.task_manager.addTask(report_task)
 
         self._report_tasks[scenario_id] = task_id
 

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -371,10 +371,10 @@ def extent_to_qgs_rectangle(
         return None
 
     return QgsRectangle(
-        spatial_extent.bbox[3],
+        spatial_extent.bbox[0],
         spatial_extent.bbox[2],
         spatial_extent.bbox[1],
-        spatial_extent.bbox[0],
+        spatial_extent.bbox[3],
     )
 
 


### PR DESCRIPTION
This PR contains the following updates to the reporting functionality:
- Correct calculation of the area for implementation models' pixels in the output scenario dataset
- Granular progress reporting of report generation process
- Visual enhancements to the main legend including renaming of legend title, removal of non-scenario legend items
- Zooming of map items in the report using the updated convention for defining scenario extents
- Filter IM layers in a report's legend to use only those ones specified in the scenario