### PR TITLE
Enable/Disable Run Scenario Button based on Analysis State

### DIFF
--- a/src/cplus_plugin/gui/progress_dialog.py
+++ b/src/cplus_plugin/gui/progress_dialog.py
@@ -28,6 +28,8 @@ Ui_DlgProgress, _ = uic.loadUiType(
 class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
     """This progress dialog"""
 
+    analysis_cancelled = QtCore.pyqtSignal()
+
     def __init__(
         self,
         init_message="Processing",
@@ -197,6 +199,8 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
         Processing will be stopped, and the UI will be updated to accommodate
         the processing status.
         """
+        self.analysis_cancelled.emit()
+
         self.cancel_reporting()
 
         if self.analysis_running:
@@ -213,6 +217,7 @@ class ProgressDialog(QtWidgets.QDialog, Ui_DlgProgress):
 
     def reject(self) -> None:
         """Called when the dialog is closed"""
+        self.analysis_cancelled.emit()
 
         if self.analysis_running:
             # Stops analysis if it is still running

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1584,6 +1584,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             if self.task:
                 self.task.cancel()
         except Exception as e:
+            self.on_progress_dialog_cancelled()
             log(f"Problem cancelling task, {e}")
 
         # Report generating task
@@ -1591,6 +1592,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             if self.reporting_feedback:
                 self.reporting_feedback.cancel()
         except Exception as e:
+            self.on_progress_dialog_cancelled()
             log(f"Problem cancelling report generating task, {e}")
 
     def scenario_results(self, success, output):
@@ -1997,4 +1999,5 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
     def on_progress_dialog_cancelled(self):
         """Slot raised when analysis has been cancelled in progress dialog."""
-        self.run_scenario_btn.setEnabled(True)
+        if not self.run_scenario_btn.isEnabled():
+            self.run_scenario_btn.setEnabled(True)


### PR DESCRIPTION
Prevent user from initiating a new scenario-analysis run when there is already an ongoing one.