### PR TITLE
Changed format of the passed priority groups

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -590,11 +590,17 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         self.position_feedback = QgsProcessingFeedback()
         self.processing_context = QgsProcessingContext()
 
-        self.analysis_priority_layers_groups = [
-            layer.get("groups")
-            for layer in settings_manager.get_priority_layers()
-            if layer.get("groups") is not [] or layer.get("groups") is not None
-        ]
+        for group in settings_manager.get_priority_groups():
+            group_layer_dict = {
+                "name": group.get("name"),
+                "value": group.get("value"),
+                "layers": [],
+            }
+            for layer in settings_manager.get_priority_layers():
+                group_names = [group.get("name") for group in layer.get("groups", [])]
+                if group.get("name") in group_names:
+                    group_layer_dict["layers"].append(layer.get("name"))
+            self.analysis_priority_layers_groups.append(group_layer_dict)
 
         self.analysis_implementation_models = [
             item.implementation_model


### PR DESCRIPTION
Implemented a new format for storing the used scenario analysis groups. The new format will contain a list of dictionary that will have a group name, group value and a list of the groups priority weighiting layers names.

The new format example of the priority groups list
`
[{'name': 'Climate Resilience', 'value': '46', 'layers': ['Bush_Thinning_carbonimpact', 'Bush_Thinning_mtrends_re', 'Bush_Thinning_NPV_re', 'Assisted_Nat_Regen_years', 'Assisted_Nat_Regen_NPV_re']},{'name': 'Finance - Carbon', 'value': '38', 'layers': ['Eat_Fresh_years', 'Alien_Plant_Removal_mtrends_re', 'Herding_4_Health_years']}, {'name': 'Biodiversity', 'value': '10', 'layers': ['biocombine_clip_norm', 'Test']}]
`