### PR TITLE
New setting for weighting and layer coefficient importance

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -142,6 +142,9 @@ class Settings(enum.Enum):
     # Coefficient for carbon layers
     CARBON_COEFFICIENT = "carbon_coefficient"
 
+    # Coefficients importance value
+    COEFFICIENT_IMPORTANCE = "coefficients_importance"
+
 
 class SettingsManager(QtCore.QObject):
     """Manages saving/loading settings for the plugin in QgsSettings."""

--- a/src/cplus_plugin/settings.py
+++ b/src/cplus_plugin/settings.py
@@ -231,6 +231,12 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         coefficient = self.carbon_coefficient_box.value()
         settings_manager.set_value(Settings.CARBON_COEFFICIENT, coefficient)
 
+        # Coefficients importance
+        coefficients_importance = self.coefficients_importance_box.value()
+        settings_manager.set_value(
+            Settings.COEFFICIENT_IMPORTANCE, coefficients_importance
+        )
+
         # Checks if the provided base directory exists
         if not os.path.exists(base_dir_path):
             iface.messageBar().pushCritical(
@@ -288,6 +294,12 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             Settings.CARBON_COEFFICIENT, default=0.0
         )
         self.carbon_coefficient_box.setValue(float(coefficient))
+
+        # Coefficients importance
+        coefficients_importance = settings_manager.get_value(
+            Settings.COEFFICIENT_IMPORTANCE, default=5
+        )
+        self.coefficients_importance_box.setValue(int(coefficients_importance))
 
     def showEvent(self, event: QShowEvent) -> None:
         """Show event being called. This will display the plugin settings.

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -164,23 +164,6 @@
           <string>Advanced</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="2" column="1">
-           <widget class="QgsFileWidget" name="folder_data">
-            <property name="storageMode">
-             <enum>QgsFileWidget::GetDirectory</enum>
-            </property>
-            <property name="options">
-             <set>QFileDialog::ShowDirsOnly</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lbl_data_dir">
-            <property name="text">
-             <string>Base data directory</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="carbon_coefficien_la">
             <property name="toolTip">
@@ -188,6 +171,13 @@
             </property>
             <property name="text">
              <string>Coefficient for carbon layers</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lbl_data_dir">
+            <property name="text">
+             <string>Base data directory</string>
             </property>
            </widget>
           </item>
@@ -207,6 +197,42 @@
             </property>
             <property name="value">
              <double>0.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsFileWidget" name="folder_data">
+            <property name="storageMode">
+             <enum>QgsFileWidget::GetDirectory</enum>
+            </property>
+            <property name="options">
+             <set>QFileDialog::ShowDirsOnly</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Used to specify the level of importance for the used coefficients when weighting the implementation models with the priority weighting layers and when combining carbon layers with the NCS pathways.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Coefficients importance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QSpinBox" name="coefficients_importance_box">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Used to specify the level of importance for the used coefficients when weighting the implementation models with the priority weighting layers and when combining carbon layers with the NCS pathways.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>5</number>
+            </property>
+            <property name="value">
+             <number>5</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Adds new setting that defines the importance to which the priority layer weighting and the carbon layers combination needs to adhere to. Currently the implementation models weighting coefficients are 0 to 1, this new setting will allow user to set the weighting coefficient from 0 to 1 up to 0 to 5.

If this new setting is set to 5, models weighting using 100% value expression will be  `'"Target_model@1" + (5.0*"Used_priority_weighting_layer@1")`

Screenshot
![Workspace 1_014](https://github.com/kartoza/cplus-plugin/assets/2663775/5757eb44-e7c9-4957-9b7d-2cafe7439ccf)

This PR also contains fix for an issue when editing the priority weighting layers from step 3, where all the priority groups are reset and their corresponding children items are remove.
