### PR TITLE
Unique Model Component Names

### DIFF
--- a/src/cplus_plugin/gui/implementation_model_editor_dialog.py
+++ b/src/cplus_plugin/gui/implementation_model_editor_dialog.py
@@ -28,7 +28,7 @@ WidgetUi, _ = loadUiType(
 class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
     """Dialog for creating or editing an implementation model entry."""
 
-    def __init__(self, parent=None, implementation_model=None):
+    def __init__(self, parent=None, implementation_model=None, excluded_names=None):
         super().__init__(parent)
         self.setupUi(self)
 
@@ -45,6 +45,10 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self._edit_mode = False
         self._layer = None
+
+        self._excluded_names = excluded_names
+        if excluded_names is None:
+            self._excluded_names = []
 
         self._implementation_model = implementation_model
         if self._implementation_model is not None:
@@ -120,8 +124,19 @@ class ImplementationModelEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self._message_bar.clearWidgets()
 
-        if not self.txt_name.text():
-            msg = tr("Implementation model name is required.")
+        name = self.txt_name.text()
+        if not name:
+            msg = tr("Implementation model name cannot be empty.")
+            self._show_warning_message(msg)
+            status = False
+
+        if name.lower() in self._excluded_names:
+            msg = tr("name has already been used.")
+            self._show_warning_message(f"'{name}' {msg}")
+            status = False
+
+        if not self.txt_description.text():
+            msg = tr("Description cannot be empty.")
             self._show_warning_message(msg)
             status = False
 

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -338,8 +338,13 @@ class NcsComponentWidget(ModelComponentWidget):
             return
 
         item = selected_items[0]
+
+        # If editing, remove the current name of the model component
+        excluded_names = self.model_names()
+        excluded_names.remove(item.model_component.name.lower())
+
         ncs_editor = NcsPathwayEditorDialog(
-            self, item.ncs_pathway, excluded_names=self.model_names()
+            self, item.ncs_pathway, excluded_names=excluded_names
         )
         if ncs_editor.exec_() == QtWidgets.QDialog.Accepted:
             ncs_pathway = ncs_editor.ncs_pathway
@@ -418,6 +423,20 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
         """
         return self.item_model.models()
 
+    def model_names(self) -> typing.List[str]:
+        """Gets the names of the implementation models in the item model.
+
+        :returns: Returns the names of implementation models in lower
+        case or an empty list if the item model has not been set.
+        :rtype: list
+        """
+        if self._item_model is None:
+            return []
+
+        model_components = self._item_model.models()
+
+        return [mc.name.lower() for mc in model_components]
+
     def on_pathways_updated(self, im_item: ImplementationModelItem):
         """Slot raised when the pathways of an ImplementationModelItem
         have been added or removed. Persist this information in settings.
@@ -449,7 +468,9 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
 
     def _on_add_item(self):
         """Show implementation model editor."""
-        editor = ImplementationModelEditorDialog(self)
+        editor = ImplementationModelEditorDialog(
+            self, excluded_names=self.model_names()
+        )
         if editor.exec_() == QtWidgets.QDialog.Accepted:
             model = editor.implementation_model
             layer = editor.layer
@@ -464,7 +485,14 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
             return
 
         item = selected_items[0]
-        editor = ImplementationModelEditorDialog(self, item.implementation_model)
+
+        # If editing, remove the current name of the model component
+        excluded_names = self.model_names()
+        excluded_names.remove(item.model_component.name.lower())
+
+        editor = ImplementationModelEditorDialog(
+            self, item.implementation_model, excluded_names=excluded_names
+        )
         if editor.exec_() == QtWidgets.QDialog.Accepted:
             model = editor.implementation_model
             layer = editor.layer

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -254,6 +254,20 @@ class ModelComponentWidget(QtWidgets.QWidget, WidgetUi):
         """
         self.load()
 
+    def model_names(self) -> typing.List[str]:
+        """Gets the names of the components in the item model.
+
+        :returns: Returns the model names in lower case or an empty
+        list if the item model has not been set.
+        :rtype: list
+        """
+        if self._item_model is None:
+            return []
+
+        model_components = self._item_model.model_components()
+
+        return [mc.name.lower() for mc in model_components]
+
 
 class NcsComponentWidget(ModelComponentWidget):
     """Widget for displaying and managing NCS pathways."""
@@ -310,7 +324,7 @@ class NcsComponentWidget(ModelComponentWidget):
 
     def _on_add_item(self):
         """Show NCS pathway editor."""
-        ncs_editor = NcsPathwayEditorDialog(self)
+        ncs_editor = NcsPathwayEditorDialog(self, excluded_names=self.model_names())
         if ncs_editor.exec_() == QtWidgets.QDialog.Accepted:
             ncs_pathway = ncs_editor.ncs_pathway
             result = self.item_model.add_ncs_pathway(ncs_pathway)
@@ -324,7 +338,9 @@ class NcsComponentWidget(ModelComponentWidget):
             return
 
         item = selected_items[0]
-        ncs_editor = NcsPathwayEditorDialog(self, item.ncs_pathway)
+        ncs_editor = NcsPathwayEditorDialog(
+            self, item.ncs_pathway, excluded_names=self.model_names()
+        )
         if ncs_editor.exec_() == QtWidgets.QDialog.Accepted:
             ncs_pathway = ncs_editor.ncs_pathway
             result = self.item_model.update_ncs_pathway(ncs_pathway)

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -164,7 +164,7 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         name = self.txt_name.text()
         if not name:
-            msg = tr("Name cannot be empty.")
+            msg = tr("NCS pathway name cannot be empty.")
             self._show_warning_message(msg)
             status = False
 

--- a/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
+++ b/src/cplus_plugin/gui/ncs_pathway_editor_dialog.py
@@ -27,7 +27,7 @@ WidgetUi, _ = loadUiType(
 class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
     """Dialog for creating or editing an NCS pathway entry."""
 
-    def __init__(self, parent=None, ncs_pathway=None):
+    def __init__(self, parent=None, ncs_pathway=None, excluded_names=None):
         super().__init__(parent)
         self.setupUi(self)
 
@@ -70,6 +70,10 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
             Settings.CARBON_COEFFICIENT, 0.0, float
         )
         self.sb_carbon_coefficient.setValue(carbon_coefficient)
+
+        self._excluded_names = excluded_names
+        if excluded_names is None:
+            self._excluded_names = []
 
         self._edit_mode = False
         self._layer = None
@@ -158,9 +162,15 @@ class NcsPathwayEditorDialog(QtWidgets.QDialog, WidgetUi):
 
         self._message_bar.clearWidgets()
 
-        if not self.txt_name.text():
+        name = self.txt_name.text()
+        if not name:
             msg = tr("Name cannot be empty.")
             self._show_warning_message(msg)
+            status = False
+
+        if name.lower() in self._excluded_names:
+            msg = tr("name has already been used.")
+            self._show_warning_message(f"'{name}' {msg}")
             status = False
 
         if not self.txt_description.toPlainText():


### PR DESCRIPTION
Add a UI check to ensure NCS pathway or implementation model names are unique when using the respective dialogs so that we do not end up with two or more `Animal Management` NCS pathways or `Bush Thinning` items in the list view.