### PR TITLE
Suitability index added to settings

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -145,6 +145,9 @@ class Settings(enum.Enum):
     # Coefficients importance value
     COEFFICIENT_IMPORTANCE = "coefficients_importance"
 
+    # Pathway suitability index value
+    PATHWAY_SUITABILITY_INDEX = "pathway_suitability_index"
+
 
 class SettingsManager(QtCore.QObject):
     """Manages saving/loading settings for the plugin in QgsSettings."""

--- a/src/cplus_plugin/settings.py
+++ b/src/cplus_plugin/settings.py
@@ -237,6 +237,12 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             Settings.COEFFICIENT_IMPORTANCE, coefficients_importance
         )
 
+        # Pathway suitability index
+        pathway_suitability_index = self.suitability_index_box.value()
+        settings_manager.set_value(
+            Settings.PATHWAY_SUITABILITY_INDEX, pathway_suitability_index
+        )
+
         # Checks if the provided base directory exists
         if not os.path.exists(base_dir_path):
             iface.messageBar().pushCritical(
@@ -300,6 +306,12 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
             Settings.COEFFICIENT_IMPORTANCE, default=5
         )
         self.coefficients_importance_box.setValue(int(coefficients_importance))
+
+        # Pathway suitability index
+        pathway_suitability_index = settings_manager.get_value(
+            Settings.PATHWAY_SUITABILITY_INDEX, default=0
+        )
+        self.suitability_index_box.setValue(float(pathway_suitability_index))
 
     def showEvent(self, event: QShowEvent) -> None:
         """Show event being called. This will display the plugin settings.

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -164,23 +164,6 @@
           <string>Advanced</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="3" column="0">
-           <widget class="QLabel" name="carbon_coefficien_la">
-            <property name="toolTip">
-             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
-            </property>
-            <property name="text">
-             <string>Coefficient for carbon layers</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lbl_data_dir">
-            <property name="text">
-             <string>Base data directory</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="1">
            <widget class="QDoubleSpinBox" name="carbon_coefficient_box">
             <property name="toolTip">
@@ -200,16 +183,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QgsFileWidget" name="folder_data">
-            <property name="storageMode">
-             <enum>QgsFileWidget::GetDirectory</enum>
-            </property>
-            <property name="options">
-             <set>QFileDialog::ShowDirsOnly</set>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="0">
            <widget class="QLabel" name="label">
             <property name="toolTip">
@@ -217,6 +190,26 @@
             </property>
             <property name="text">
              <string>Coefficients importance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="carbon_coefficien_la">
+            <property name="toolTip">
+             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
+            </property>
+            <property name="text">
+             <string>Coefficient for carbon layers</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsFileWidget" name="folder_data">
+            <property name="storageMode">
+             <enum>QgsFileWidget::GetDirectory</enum>
+            </property>
+            <property name="options">
+             <set>QFileDialog::ShowDirsOnly</set>
             </property>
            </widget>
           </item>
@@ -233,6 +226,33 @@
             </property>
             <property name="value">
              <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lbl_data_dir">
+            <property name="text">
+             <string>Base data directory</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="lbl_suitability_index">
+            <property name="text">
+             <string>Pathway suitability index</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="suitability_index_box">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>5.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.500000000000000</double>
             </property>
            </widget>
           </item>

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -31,6 +31,10 @@ class CplusPluginSettingsTest(unittest.TestCase):
         save_report_license = "license"
         save_base_dir = "base directory"
 
+        carbon_coefficient = 0.15
+        coefficient_importance = 3
+        pathway_suitability_index = 1.5
+
         # Sets the values in the GUI
         settings_dialog.txt_organization.setText(save_organization)
         settings_dialog.txt_email.setText(save_email)
@@ -41,6 +45,10 @@ class CplusPluginSettingsTest(unittest.TestCase):
         settings_dialog.txt_disclaimer.setPlainText(save_disclaimer)
         settings_dialog.txt_license.setText(save_report_license)
         settings_dialog.folder_data.setFilePath(save_base_dir)
+
+        settings_dialog.carbon_coefficient_box.setValue(carbon_coefficient)
+        settings_dialog.coefficients_importance_box.setValue(coefficient_importance)
+        settings_dialog.suitability_index_box.setValue(pathway_suitability_index)
 
         # Saves the settings set in the GUI
         settings_dialog.save_settings()
@@ -73,6 +81,19 @@ class CplusPluginSettingsTest(unittest.TestCase):
         base_dir = settings_manager.get_value(Settings.BASE_DIR)
         self.assertEqual(save_base_dir, base_dir)
 
+        carbon_coefficient_val = settings_manager.get_value(Settings.CARBON_COEFFICIENT)
+        self.assertEqual(carbon_coefficient, carbon_coefficient_val)
+
+        coefficient_importance_val = settings_manager.get_value(
+            Settings.COEFFICIENT_IMPORTANCE
+        )
+        self.assertEqual(coefficient_importance, coefficient_importance_val)
+
+        pathway_suitability_index_val = settings_manager.get_value(
+            Settings.PATHWAY_SUITABILITY_INDEX
+        )
+        self.assertEqual(pathway_suitability_index, pathway_suitability_index_val)
+
     def test_load(self):
         """A test which will check if the CPLUS settings is loaded correctly
         into the settings UI when calling the load_settings function.
@@ -89,6 +110,10 @@ class CplusPluginSettingsTest(unittest.TestCase):
         save_report_license = "license 2"
         save_base_dir = "base directory 2"
 
+        save_carbon_coefficient = 0.15
+        save_coefficient_importance = 3
+        save_pathway_suitability_index = 1.5
+
         # Set all values for testing
         settings_manager.set_value(Settings.REPORT_ORGANIZATION, save_organization)
         settings_manager.set_value(Settings.REPORT_CONTACT_EMAIL, save_email)
@@ -101,6 +126,14 @@ class CplusPluginSettingsTest(unittest.TestCase):
         settings_manager.set_value(Settings.REPORT_DISCLAIMER, save_disclaimer)
         settings_manager.set_value(Settings.REPORT_LICENSE, save_report_license)
         settings_manager.set_value(Settings.BASE_DIR, save_base_dir)
+
+        settings_manager.set_value(Settings.CARBON_COEFFICIENT, save_carbon_coefficient)
+        settings_manager.set_value(
+            Settings.COEFFICIENT_IMPORTANCE, save_coefficient_importance
+        )
+        settings_manager.set_value(
+            Settings.PATHWAY_SUITABILITY_INDEX, save_pathway_suitability_index
+        )
 
         # Loads the values into the GUI
         settings_dialog.load_settings()
@@ -132,6 +165,15 @@ class CplusPluginSettingsTest(unittest.TestCase):
 
         base_dir_path = settings_dialog.folder_data.filePath()
         self.assertEqual(save_base_dir, base_dir_path)
+
+        carbon_coefficient = settings_dialog.carbon_coefficient_box.value()
+        self.assertEqual(save_carbon_coefficient, carbon_coefficient)
+
+        coefficient_importance = settings_dialog.coefficients_importance_box.value()
+        self.assertEqual(save_coefficient_importance, coefficient_importance)
+
+        pathway_suitability_index = settings_dialog.suitability_index_box.value()
+        self.assertEqual(save_pathway_suitability_index, pathway_suitability_index)
 
     def test_base_dir_exist(self):
         """A test which checks if the base_dir_exists function works


### PR DESCRIPTION
Fixes #228
Fixes #229
Fixes #230 

- Added the Pathway suitability index to the settings
- Saves and loads value correctly
- Added test for the Suitability index saving and loading
- Also added tests for the Carbon coefficient and coefficient importance, as there were no tests
- Doc strings will update as settings already has a mkdocstring
- Documentation is added to https://github.com/kartoza/cplus-plugin/pull/225 (to avoid merging clashes with the documentation PR)

![image](https://github.com/kartoza/cplus-plugin/assets/79740955/357db21c-dd77-43c9-bc54-62367c44d86d)
