### PR TITLE
Pathways weighting using carbon layers update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .idea/
 build/
 cplus_scenario_output.*
+[Skip output]

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -944,10 +944,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
         new_carbon_directory = f"{self.scenario_directory}/pathways_carbon_layers"
 
-        coefficient_importance = settings_manager.get_value(
-            Settings.COEFFICIENT_IMPORTANCE, default=5
-        )
-
         suitability_index = float(
             settings_manager.get_value(Settings.PATHWAY_SUITABILITY_INDEX, default=0)
         )
@@ -955,7 +951,6 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         carbon_coefficient = float(
             settings_manager.get_value(Settings.CARBON_COEFFICIENT, default=0.0)
         )
-        carbon_coefficient = int(coefficient_importance) * carbon_coefficient
 
         base_dir = settings_manager.get_value(Settings.BASE_DIR)
 

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -173,10 +173,10 @@
              <number>1</number>
             </property>
             <property name="maximum">
-             <double>1.000000000000000</double>
+             <double>5.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.050000000000000</double>
+             <double>1.000000000000000</double>
             </property>
             <property name="value">
              <double>0.000000000000000</double>


### PR DESCRIPTION
Fixes https://github.com/kartoza/cplus-plugin/issues/240

Updates the current NCS pathways weighting calculations by the carbon layers to include all the carbon layers in case where a pathway has more than one carbon layers.

The PR also removes the usage of the `coefficient of importance` setting when doing the pathway weighting, the weighting calculations now only take into account the `carbon coefficient` which is now ranged from 0 to 5.