### PR TITLE
Update NCS Pathways on Updating Base Directory

### DIFF
--- a/src/cplus_plugin/gui/implementation_model_widget.py
+++ b/src/cplus_plugin/gui/implementation_model_widget.py
@@ -10,6 +10,7 @@ from qgis.PyQt import QtWidgets
 
 from qgis.PyQt.uic import loadUiType
 
+from ..conf import Settings, settings_manager
 from .component_item_model import ImplementationModelItem, ModelComponentItemType
 
 from .model_component_widget import (
@@ -55,6 +56,7 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
         self.ipm_layout.addWidget(self.implementation_model_view)
         self.implementation_model_view.title = self.tr("Implementation Models")
 
+        settings_manager.settings_updated[str, object].connect(self.on_settings_changed)
         self.ncs_pathway_view.ncs_pathway_updated.connect(self.on_ncs_pathway_updated)
 
         self.load()
@@ -109,6 +111,20 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
     def on_ncs_pathway_updated(self, ncs_pathway: NcsPathway):
         """Slot raised when an NCS pathway has been updated."""
         self.implementation_model_view.update_ncs_pathway_items(ncs_pathway)
+
+    def on_settings_changed(self, name: str, value: typing.Any):
+        """Slot raised when settings has been changed.
+
+        :param name: Name of the setting that has changed.
+        :type name: str
+
+        :param value: New value for the given settings name.
+        :type value: Any
+        """
+        # Update the NCS pathway and carbon layer paths when
+        # BASE_DIR has been updated.
+        if name == Settings.BASE_DIR.value:
+            self.ncs_pathway_view.load()
 
     def is_valid(self) -> bool:
         """Check if the user input is valid.

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -392,7 +392,16 @@ class NcsComponentWidget(ModelComponentWidget):
 
         settings_manager.update_ncs_pathways()
         ncs_pathways = settings_manager.get_all_ncs_pathways()
-        for ncs in ncs_pathways:
+
+        progress_dialog = QtWidgets.QProgressDialog(self)
+        progress_dialog.setWindowTitle(self.tr("Load NCS Pathways"))
+        progress_dialog.setMinimum(0)
+        progress_dialog.setMaximum(len(ncs_pathways))
+        progress_dialog.setLabelText(self.tr("Updating NCS pathways..."))
+        for i, ncs in enumerate(ncs_pathways, start=1):
+            progress_dialog.setValue(i)
+            if progress_dialog.wasCanceled():
+                break
             self.add_ncs_pathway(ncs)
 
 


### PR DESCRIPTION
Automatically reload NCS pathways and corresponding carbon layers when the base directory has been updated.

Address issue #272.