### PR TITLE
Remove Carbon Coefficient in NCS

### DIFF
--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -29,7 +29,6 @@ from qgis.PyQt.QtWidgets import QMenu
 
 from .conf import Settings, settings_manager
 from .definitions.constants import (
-    CARBON_COEFFICIENT_ATTRIBUTE,
     CARBON_PATHS_ATTRIBUTE,
     NCS_CARBON_SEGMENT,
     NCS_PATHWAY_SEGMENT,

--- a/src/cplus_plugin/main.py
+++ b/src/cplus_plugin/main.py
@@ -367,11 +367,6 @@ def initialize_model_settings():
         # Create priority weighting layers subdirectory
         FileUtils.create_pwls_dir(base_dir)
 
-    # Use carbon coefficient values for older-version NCS pathways
-    carbon_coefficient = settings_manager.get_value(
-        Settings.CARBON_COEFFICIENT, 0, float
-    )
-
     # Add default pathways
     for ncs_dict in DEFAULT_NCS_PATHWAYS:
         try:
@@ -399,21 +394,7 @@ def initialize_model_settings():
                     ncs_dict[CARBON_PATHS_ATTRIBUTE] = abs_carbon_paths
 
                 ncs_dict[USER_DEFINED_ATTRIBUTE] = False
-                ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = carbon_coefficient
                 settings_manager.save_ncs_pathway(ncs_dict)
-            else:
-                # Update carbon coefficient value
-                # Check if carbon coefficient had previously been defined
-                ncs_dict = settings_manager.get_ncs_pathway_dict(ncs_uuid)
-                if CARBON_COEFFICIENT_ATTRIBUTE in ncs_dict:
-                    continue
-                else:
-                    ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = carbon_coefficient
-                    source_ncs = create_ncs_pathway(ncs_dict)
-                    if source_ncs is None:
-                        continue
-                    ncs = copy_layer_component_attributes(ncs, source_ncs)
-                    settings_manager.update_ncs_pathway(ncs)
         except KeyError as ke:
             log(f"Default NCS configuration load error - {str(ke)}")
             continue

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -201,7 +201,6 @@ class NcsPathway(LayerModelComponent):
     """Contains information about an NCS pathway layer."""
 
     carbon_paths: typing.List[str] = dataclasses.field(default_factory=list)
-    carbon_coefficient: float = 0.0
 
     def __eq__(self, other: "NcsPathway") -> bool:
         """Test equality of NcsPathway object with another

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -17,7 +17,6 @@ from .base import (
     SpatialExtent,
 )
 from ..definitions.constants import (
-    CARBON_COEFFICIENT_ATTRIBUTE,
     CARBON_PATHS_ATTRIBUTE,
     FILL_STYLE_ATTRIBUTE,
     NAME_ATTRIBUTE,
@@ -161,10 +160,6 @@ def create_ncs_pathway(source_dict) -> typing.Union[NcsPathway, None]:
     # be missing.
     if CARBON_PATHS_ATTRIBUTE in source_dict:
         ncs.carbon_paths = source_dict[CARBON_PATHS_ATTRIBUTE]
-
-    carbon_coefficient_attr = CARBON_COEFFICIENT_ATTRIBUTE
-    if carbon_coefficient_attr in source_dict:
-        ncs.carbon_coefficient = source_dict[CARBON_COEFFICIENT_ATTRIBUTE]
 
     return ncs
 

--- a/src/cplus_plugin/models/helpers.py
+++ b/src/cplus_plugin/models/helpers.py
@@ -243,7 +243,6 @@ def ncs_pathway_to_dict(ncs_pathway: NcsPathway, uuid_to_str=True) -> dict:
     """
     base_ncs_dict = layer_component_to_dict(ncs_pathway, uuid_to_str)
     base_ncs_dict[CARBON_PATHS_ATTRIBUTE] = ncs_pathway.carbon_paths
-    base_ncs_dict[CARBON_COEFFICIENT_ATTRIBUTE] = ncs_pathway.carbon_coefficient
 
     return base_ncs_dict
 

--- a/test/model_data_for_testing.py
+++ b/test/model_data_for_testing.py
@@ -46,7 +46,6 @@ def get_valid_ncs_pathway() -> NcsPathway:
         LayerType.RASTER,
         True,
         carbon_paths=[],
-        carbon_coefficient=0.0,
     )
 
 
@@ -139,5 +138,4 @@ NCS_PATHWAY_DICT = {
     LAYER_TYPE_ATTRIBUTE: 0,
     USER_DEFINED_ATTRIBUTE: True,
     CARBON_PATHS_ATTRIBUTE: [],
-    CARBON_COEFFICIENT_ATTRIBUTE: 0.0,
 }


### PR DESCRIPTION
Remove code fragments containing carbon co-efficient references in the management of NCS pathways.