### PR TITLE
Snap pathways layers

### DIFF
--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -146,6 +146,11 @@ class Settings(enum.Enum):
     # Pathway suitability index value
     PATHWAY_SUITABILITY_INDEX = "pathway_suitability_index"
 
+    # Snapping values
+    SNAP_LAYER = "snap_layer"
+    ALLOW_RESAMPLING = "snap_resampling"
+    SNAP_PIXEL_VALUE = "snap_pixel_value"
+
 
 class SettingsManager(QtCore.QObject):
     """Manages saving/loading settings for the plugin in QgsSettings."""

--- a/src/cplus_plugin/conf.py
+++ b/src/cplus_plugin/conf.py
@@ -147,8 +147,11 @@ class Settings(enum.Enum):
     PATHWAY_SUITABILITY_INDEX = "pathway_suitability_index"
 
     # Snapping values
+    SNAPPING_ENABLED = "snapping_enabled"
     SNAP_LAYER = "snap_layer"
     ALLOW_RESAMPLING = "snap_resampling"
+    RESCALE_VALUES = "snap_rescale"
+    RESAMPLING_METHOD = "snap_method"
     SNAP_PIXEL_VALUE = "snap_pixel_value"
 
 

--- a/src/cplus_plugin/gui/items_selection_dialog.py
+++ b/src/cplus_plugin/gui/items_selection_dialog.py
@@ -56,7 +56,11 @@ class ItemsSelectionDialog(QtWidgets.QDialog, DialogUi):
             model = settings_manager.get_implementation_model(str(model_uuid))
 
             layer_model_uuids = [model.uuid for model in self.models]
-            model_layer_uuids = [layer.get("uuid") for layer in model.priority_layers]
+            model_layer_uuids = [
+                layer.get("uuid")
+                for layer in model.priority_layers
+                if layer is not None
+            ]
 
             if (
                 self.layer is not None

--- a/src/cplus_plugin/gui/priority_layer_dialog.py
+++ b/src/cplus_plugin/gui/priority_layer_dialog.py
@@ -114,7 +114,9 @@ class PriorityLayerDialog(QtWidgets.QDialog, DialogUi):
 
             for model in all_models:
                 model_layer_uuids = [
-                    layer.get("uuid") for layer in model.priority_layers
+                    layer.get("uuid")
+                    for layer in model.priority_layers
+                    if layer is not None
                 ]
                 if str(self.layer.get("uuid")) in model_layer_uuids:
                     self.models.append(model)
@@ -155,7 +157,9 @@ class PriorityLayerDialog(QtWidgets.QDialog, DialogUi):
 
         for model in models:
             models_layer_uuids = [
-                str(layer.get("uuid")) for layer in model.priority_layers
+                str(layer.get("uuid"))
+                for layer in model.priority_layers
+                if layer is not None
             ]
             if str(self.layer.get("uuid")) not in models_layer_uuids:
                 model.priority_layers.append(self.layer)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -832,7 +832,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 "OUTPUT": output_file,
             }
 
-            log(f"Used parameters for highest position analysis {alg_params}")
+            log(f"Used parameters for highest position analysis {alg_params} \n")
 
             alg = QgsApplication.processingRegistry().algorithmById(
                 "native:highestpositioninrasterstack"
@@ -1056,7 +1056,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
             log(
                 f"Used parameters for combining pathways"
-                f" and carbon layers generation: {alg_params}"
+                f" and carbon layers generation: {alg_params} \n"
             )
 
             alg = QgsApplication.processingRegistry().algorithmById(
@@ -1423,7 +1423,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 "OUTPUT": output_file,
             }
 
-            log(f"Used parameters for normalization of the pathways: {alg_params}")
+            log(f"Used parameters for normalization of the pathways: {alg_params} \n")
 
             alg = QgsApplication.processingRegistry().algorithmById(
                 "qgis:rastercalculator"
@@ -1577,7 +1577,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
             log(
                 f"Used parameters for "
-                f"implementation models generation: {alg_params}"
+                f"implementation models generation: {alg_params} \n"
             )
 
             alg = QgsApplication.processingRegistry().algorithmById(
@@ -1764,7 +1764,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 "OUTPUT": output_file,
             }
 
-            log(f"Used parameters for normalization of the models: {alg_params}")
+            log(f"Used parameters for normalization of the models: {alg_params} \n")
 
             alg = QgsApplication.processingRegistry().algorithmById(
                 "qgis:rastercalculator"
@@ -1946,7 +1946,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 "OUTPUT": output_file,
             }
 
-            log(f" Used parameters for calculating weighting models {alg_params}")
+            log(f" Used parameters for calculating weighting models {alg_params} \n")
 
             alg = QgsApplication.processingRegistry().algorithmById(
                 "qgis:rastercalculator"

--- a/src/cplus_plugin/settings.py
+++ b/src/cplus_plugin/settings.py
@@ -37,7 +37,7 @@ from .definitions.defaults import (
     ICON_PATH,
     DEFAULT_LOGO_PATH,
 )
-from .utils import FileUtils
+from .utils import FileUtils, tr
 
 Ui_DlgSettings, _ = uic.loadUiType(str(Path(__file__).parent / "ui/qgis_settings.ui"))
 
@@ -70,8 +70,40 @@ class CplusSettings(Ui_DlgSettings, QgsOptionsPageWidget):
         self.map_layer_file_widget.setStorageMode(QgsFileWidget.StorageMode.GetFile)
         self.map_layer_box.layerChanged.connect(self.map_layer_changed)
 
-        for method in QgsAlignRaster.ResampleAlg:
-            self.resample_method_box.insertItem(method.value, method.name)
+        self.resample_method_box.addItem(
+            tr("Nearest Neighbour"), QgsAlignRaster.ResampleAlg.RA_NearestNeighbour
+        )
+        self.resample_method_box.addItem(
+            tr("Bilinear (2x2 Kernel)"), QgsAlignRaster.ResampleAlg.RA_Bilinear
+        )
+        self.resample_method_box.addItem(
+            tr("Cubic (4x4 Kernel)"), QgsAlignRaster.ResampleAlg.RA_Cubic
+        )
+        self.resample_method_box.addItem(
+            tr("Cubic B-Spline (4x4 Kernel)"), QgsAlignRaster.ResampleAlg.RA_CubicSpline
+        )
+        self.resample_method_box.addItem(
+            tr("Lanczos (6x6 Kernel)"), QgsAlignRaster.ResampleAlg.RA_Lanczos
+        )
+        self.resample_method_box.addItem(
+            tr("Average"), QgsAlignRaster.ResampleAlg.RA_Average
+        )
+        self.resample_method_box.addItem(tr("Mode"), QgsAlignRaster.ResampleAlg.RA_Mode)
+        self.resample_method_box.addItem(
+            tr("Maximum"), QgsAlignRaster.ResampleAlg.RA_Max
+        )
+        self.resample_method_box.addItem(
+            tr("Minimum"), QgsAlignRaster.ResampleAlg.RA_Min
+        )
+        self.resample_method_box.addItem(
+            tr("Median"), QgsAlignRaster.ResampleAlg.RA_Median
+        )
+        self.resample_method_box.addItem(
+            tr("First Quartile (Q1)"), QgsAlignRaster.ResampleAlg.RA_Q1
+        )
+        self.resample_method_box.addItem(
+            tr("Third Quartile (Q3)"), QgsAlignRaster.ResampleAlg.RA_Q3
+        )
 
     def apply(self) -> None:
         """This is called on OK click in the QGIS options panel."""

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -164,33 +164,13 @@
           <string>Advanced</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="3" column="0">
-           <widget class="QLabel" name="carbon_coefficien_la">
-            <property name="toolTip">
-             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
+          <item row="2" column="1">
+           <widget class="QgsFileWidget" name="folder_data">
+            <property name="storageMode">
+             <enum>QgsFileWidget::GetDirectory</enum>
             </property>
-            <property name="text">
-             <string>Coefficient for carbon layers</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lbl_data_dir">
-            <property name="text">
-             <string>Base data directory</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="suitability_index_box">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <double>5.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
+            <property name="options">
+             <set>QFileDialog::ShowDirsOnly</set>
             </property>
            </widget>
           </item>
@@ -213,6 +193,23 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lbl_data_dir">
+            <property name="text">
+             <string>Base data directory</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="carbon_coefficien_la">
+            <property name="toolTip">
+             <string>The value that will be used as a coefficient when combining pathways with carbon layers. </string>
+            </property>
+            <property name="text">
+             <string>Coefficient for carbon layers</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="0">
            <widget class="QLabel" name="lbl_suitability_index">
             <property name="text">
@@ -220,44 +217,58 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QgsFileWidget" name="folder_data">
-            <property name="storageMode">
-             <enum>QgsFileWidget::GetDirectory</enum>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="suitability_index_box">
+            <property name="decimals">
+             <number>1</number>
             </property>
-            <property name="options">
-             <set>QFileDialog::ShowDirsOnly</set>
+            <property name="maximum">
+             <double>5.000000000000000</double>
             </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsCollapsibleGroupBox" name="snapping_group_box">
-         <property name="title">
-          <string>Snapping</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QCheckBox" name="rescale_values">
-            <property name="text">
-             <string>Enable pixel values rescaling</string>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QCheckBox" name="resample_values">
-            <property name="text">
-             <string>Allow resampling</string>
+          <item row="5" column="0" colspan="2">
+           <widget class="QgsCollapsibleGroupBox" name="snapping_group_box">
+            <property name="title">
+             <string>Snapping</string>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="load_snap_dialog">
-            <property name="text">
-             <string>Open snap dialog</string>
-            </property>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <widget class="QCheckBox" name="resample_values">
+               <property name="text">
+                <string>Allow resampling</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="reference_layer_label">
+               <property name="text">
+                <string>Reference layer</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item>
+                <widget class="QgsFileWidget" name="map_layer_file_widget">
+                 <property name="toolTip">
+                  <string>Select the priority layer from the local filesystem.</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsMapLayerComboBox" name="map_layer_box">
+                 <property name="toolTip">
+                  <string>Select priority layer from the current QGIS map layers.</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -293,6 +304,11 @@
    <class>QgsFileWidget</class>
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsmaplayercombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsScrollArea</class>

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>592</width>
-    <height>646</height>
+    <width>594</width>
+    <height>687</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -36,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>570</width>
-        <height>624</height>
+        <width>572</width>
+        <height>665</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -227,6 +227,36 @@
             </property>
             <property name="options">
              <set>QFileDialog::ShowDirsOnly</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="snapping_group_box">
+         <property name="title">
+          <string>Snapping</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="rescale_values">
+            <property name="text">
+             <string>Enable pixel values rescaling</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="resample_values">
+            <property name="text">
+             <string>Allow resampling</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="load_snap_dialog">
+            <property name="text">
+             <string>Open snap dialog</string>
             </property>
            </widget>
           </item>

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -243,13 +243,6 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QCheckBox" name="rescale_values">
-               <property name="text">
-                <string>Rescale values</string>
-               </property>
-              </widget>
-             </item>
-             <item>
               <layout class="QHBoxLayout" name="horizontalLayout_2">
                <item>
                 <widget class="QLabel" name="resample_method">
@@ -287,6 +280,13 @@
                 </widget>
                </item>
               </layout>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="rescale_values">
+               <property name="text">
+                <string>Rescale values</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/src/cplus_plugin/ui/qgis_settings.ui
+++ b/src/cplus_plugin/ui/qgis_settings.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>594</width>
-    <height>687</height>
+    <height>719</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -37,7 +37,7 @@
         <x>0</x>
         <y>0</y>
         <width>572</width>
-        <height>665</height>
+        <height>697</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -235,13 +235,33 @@
             <property name="title">
              <string>Snapping</string>
             </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QCheckBox" name="resample_values">
+              <widget class="QCheckBox" name="rescale_values">
                <property name="text">
-                <string>Allow resampling</string>
+                <string>Rescale values</string>
                </property>
               </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="resample_method">
+                 <property name="text">
+                  <string>Resample method</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="resample_method_box"/>
+               </item>
+              </layout>
              </item>
              <item>
               <widget class="QLabel" name="reference_layer_label">

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -302,8 +302,9 @@ def align_rasters(
         log(f"Problem occured when snapping, {str(e)}")
 
     log(
-        f"Finished snapping with original layer - {input_raster_source}, "
-        f"snapped output - {input_layer_output}"
+        f"Finished snapping using resampling method {resample_method_value.name} with"
+        f" original layer - {input_raster_source}, "
+        f"snapped output - {input_layer_output} \n"
     )
 
     return input_layer_output, None

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -228,7 +228,7 @@ def align_rasters(
     :param extent: Clip extent
     :type extent: list
 
-    :param output_dir: Output directory for the snapped
+    :param output_dir: Absolute path of the output directory for the snapped
     layers
     :type output_dir: str
 
@@ -244,6 +244,9 @@ def align_rasters(
 
     input_layer_output = f"{directory}/{uuid.uuid4()[5]}.tif"
     reference_layer_output = f"{directory}/{uuid.uuid4()[5]}.tif"
+
+    FileUtils.create_new_file(input_layer_output)
+    FileUtils.create_new_file(reference_layer_output)
 
     align = QgsAlignRaster()
     lst = [


### PR DESCRIPTION
Fixes https://github.com/kartoza/cplus-plugin/issues/40

Adds implementation for snapping pathways layers using a defined reference layer from the settings/option page.

Current workflow only snaps pathways one time and that is after adding the pathways together with carbon layer. User can select whether to rescale values and the resampling method to be used in the snapping through changing the new snap settings defined under the advanced group box from settings page.

The PR also contain related fixes from the third tab priority weighting layer functionality

![image](https://github.com/kartoza/cplus-plugin/assets/2663775/f12c06b5-b323-4ae9-9d6a-34ed2e897f78)


