### PR TITLE
Use a correct reference layer value when snapping

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -1228,7 +1228,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             snapping_enabled = settings_manager.get_value(
                 Settings.SNAPPING_ENABLED, default=False, setting_type=bool
             )
-            reference_layer = settings_manager.get_value(Settings.SNAP_LAYER)
+            reference_layer = settings_manager.get_value(
+                Settings.SNAP_LAYER, default=""
+            )
             reference_layer_path = Path(reference_layer)
             if (
                 snapping_enabled


### PR DESCRIPTION
Fixes a bug when user hasn't specified the reference layer to be used for snapping.

Error
![image](https://github.com/kartoza/cplus-plugin/assets/2663775/4ffb302e-98c5-42e1-9ec8-acd424405778)
