### PR TITLE
Item Editor on Double Click

### DIFF
--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -212,7 +212,11 @@ class ModelComponentWidget(QtWidgets.QWidget, WidgetUi):
         self._update_ui_on_selection_changed()
 
     def _on_double_click_item(self, index: QtCore.QModelIndex):
-        """Slot raised when an item has been double-clicked."""
+        """Slot raised when an item has been double-clicked.
+
+        :param index: Index of the clicked item.
+        :type index: QtCore.QModelIndex
+        """
         if self._item_model is None:
             return
 
@@ -401,7 +405,11 @@ class NcsComponentWidget(ModelComponentWidget):
         self._edit_ncs_pathway_item(item)
 
     def _handle_double_click(self, item: NcsPathwayItem):
-        """Show editor dialog."""
+        """Show editor dialog.
+
+        :param item: NCS pathway item receiving the event.
+        :type item: NcsPathwayItem
+        """
         self._edit_ncs_pathway_item(item)
 
     def _edit_ncs_pathway_item(self, item: NcsPathwayItem):
@@ -595,7 +603,12 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
         self._edit_implementation_model_item(item)
 
     def _handle_double_click(self, item: ImplementationModelItem):
-        """Show dialog for editing implementation model."""
+        """Show dialog for editing implementation model.
+
+        :param item: Implementation model item that has received the
+        event.
+        :type item: ImplementationModelItem
+        """
         self._edit_implementation_model_item(item)
 
     def _edit_implementation_model_item(self, item):

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -51,6 +51,8 @@ class ModelComponentWidget(QtWidgets.QWidget, WidgetUi):
         if self._item_model is not None:
             self.item_model = self._item_model
 
+        self.lst_model_items.doubleClicked.connect(self._on_double_click_item)
+
         add_icon = FileUtils.get_icon("symbologyAdd.svg")
         self.btn_add.setIcon(add_icon)
         self.btn_add.clicked.connect(self._on_add_item)
@@ -208,6 +210,31 @@ class ModelComponentWidget(QtWidgets.QWidget, WidgetUi):
         :type deselected: QtCore.QItemSelection
         """
         self._update_ui_on_selection_changed()
+
+    def _on_double_click_item(self, index: QtCore.QModelIndex):
+        """Slot raised when an item has been double-clicked."""
+        if self._item_model is None:
+            return
+
+        item = self._item_model.itemFromIndex(index)
+        if item is None:
+            return
+
+        if not item.isEnabled():
+            return
+
+        self._handle_double_click(item)
+
+    def _handle_double_click(self, item: ModelComponentItemType):
+        """Handle double-clicking of an item.
+
+        To be implemented by sub-classes.
+
+        :param item: Model component item that has received the
+        double click event.
+        :type item: ModelComponentItem
+        """
+        pass
 
     def _update_ui_on_selection_changed(self):
         """Update UI properties on selection changed."""
@@ -371,11 +398,17 @@ class NcsComponentWidget(ModelComponentWidget):
             return
 
         item = selected_items[0]
+        self._edit_ncs_pathway_item(item)
 
+    def _handle_double_click(self, item: NcsPathwayItem):
+        """Show editor dialog."""
+        self._edit_ncs_pathway_item(item)
+
+    def _edit_ncs_pathway_item(self, item: NcsPathwayItem):
+        """Shows dialog for editing an item."""
         # If editing, remove the current name of the model component
         excluded_names = self.model_names()
         excluded_names.remove(item.model_component.name.lower())
-
         ncs_editor = NcsPathwayEditorDialog(
             self, item.ncs_pathway, excluded_names=excluded_names
         )
@@ -559,11 +592,17 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
             return
 
         item = selected_items[0]
+        self._edit_implementation_model_item(item)
 
+    def _handle_double_click(self, item: ImplementationModelItem):
+        """Show dialog for editing implementation model."""
+        self._edit_implementation_model_item(item)
+
+    def _edit_implementation_model_item(self, item):
+        """Load dialog for editing implementation model."""
         # If editing, remove the current name of the model component
         excluded_names = self.model_names()
         excluded_names.remove(item.model_component.name.lower())
-
         editor = ImplementationModelEditorDialog(
             self, item.implementation_model, excluded_names=excluded_names
         )

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -203,6 +203,10 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         self.edit_pwl_btn.clicked.connect(self.edit_priority_layer)
         self.remove_pwl_btn.clicked.connect(self.remove_priority_layer)
 
+        self.priority_layers_list.itemDoubleClicked.connect(
+            self._on_double_click_priority_layer
+        )
+
         # Add priority groups list into the groups frame
         self.priority_groups_list = CustomTreeWidget()
 
@@ -621,12 +625,23 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
         current_text = self.priority_layers_list.currentItem().data(
             QtCore.Qt.DisplayRole
         )
+
         if current_text == "":
             self.show_message(
                 tr("Could not fetch the selected priority layer for editing."),
                 Qgis.Critical,
             )
             return
+
+        self._show_priority_layer_editor(current_text)
+
+    def _on_double_click_priority_layer(self, list_item: QtWidgets.QListWidgetItem):
+        """Slot raised when a priority list item has been double clicked."""
+        layer_name = list_item.text()
+        self._show_priority_layer_editor(layer_name)
+
+    def _show_priority_layer_editor(self, current_text):
+        """Shows the dialog for editing a priority layer."""
         layer = settings_manager.find_layer_by_name(current_text)
         layer_dialog = PriorityLayerDialog(layer)
         layer_dialog.exec_()

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -639,7 +639,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
     def _on_double_click_priority_layer(self, list_item: QtWidgets.QListWidgetItem):
         """Slot raised when a priority list item has been double clicked."""
-        layer_name = list_item.text()
+        layer_name = list_item.data(QtCore.Qt.DisplayRole)
         self._show_priority_layer_editor(layer_name)
 
     def _show_priority_layer_editor(self, current_text):

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -624,27 +624,29 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 Qgis.Critical,
             )
             return
-        current_text = self.priority_layers_list.currentItem().data(
-            QtCore.Qt.DisplayRole
+
+        layer_identifier = self.priority_layers_list.currentItem().data(
+            QtCore.Qt.UserRole
         )
 
-        if current_text == "":
+        if layer_identifier == "":
             self.show_message(
                 tr("Could not fetch the selected priority layer for editing."),
                 Qgis.Critical,
             )
             return
 
-        self._show_priority_layer_editor(current_text)
+        self._show_priority_layer_editor(layer_identifier)
 
     def _on_double_click_priority_layer(self, list_item: QtWidgets.QListWidgetItem):
         """Slot raised when a priority list item has been double clicked."""
-        layer_name = list_item.data(QtCore.Qt.DisplayRole)
+        layer_name = list_item.data(QtCore.Qt.UserRole)
         self._show_priority_layer_editor(layer_name)
 
-    def _show_priority_layer_editor(self, current_text):
+    def _show_priority_layer_editor(self, layer_identifier: str):
         """Shows the dialog for editing a priority layer."""
-        layer = settings_manager.find_layer_by_name(current_text)
+        layer_uuid = uuid.UUID(layer_identifier)
+        layer = settings_manager.get_priority_layer(layer_uuid)
         layer_dialog = PriorityLayerDialog(layer)
         layer_dialog.exec_()
 

--- a/src/cplus_plugin/lib/extent_check.py
+++ b/src/cplus_plugin/lib/extent_check.py
@@ -28,10 +28,14 @@ def extent_within_pilot(new_extent: QgsRectangle) -> bool:
         extent_list[0], extent_list[2], extent_list[1], extent_list[3]
     )
 
+    print(pilot_extent.toString())
+    print(new_extent.toString())
+
     default_crs = QgsCoordinateReferenceSystem.fromEpsgId(DEFAULT_CRS_ID)
     project_crs = QgsProject.instance().crs()
 
     if default_crs != project_crs:
+        print("Projections are different")
         coordinate_xform = QgsCoordinateTransform(
             default_crs, project_crs, QgsProject.instance()
         )


### PR DESCRIPTION
UX enhancement for showing the editor dialog on double clicking an NCS pathway, implementation model or priority layer item in the list widget.