### PR TITLE
Sync Deletion of NCS Pathways in Implementation Models

### DIFF
--- a/src/cplus_plugin/gui/implementation_model_widget.py
+++ b/src/cplus_plugin/gui/implementation_model_widget.py
@@ -66,6 +66,7 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
 
         settings_manager.settings_updated[str, object].connect(self.on_settings_changed)
         self.ncs_pathway_view.ncs_pathway_updated.connect(self.on_ncs_pathway_updated)
+        self.ncs_pathway_view.ncs_pathway_removed.connect(self.on_ncs_pathway_removed)
         self.ncs_pathway_view.items_reloaded.connect(self._on_ncs_pathways_reloaded)
 
         self.load()
@@ -124,6 +125,14 @@ class ImplementationModelContainerWidget(QtWidgets.QWidget, WidgetUi):
     def on_ncs_pathway_updated(self, ncs_pathway: NcsPathway):
         """Slot raised when an NCS pathway has been updated."""
         self.implementation_model_view.update_ncs_pathway_items(ncs_pathway)
+
+    def on_ncs_pathway_removed(self, ncs_pathway_uuid: str):
+        """Slot raised when an NCS pathway has been removed.
+
+        :param ncs_pathway_uuid: Unique identified of the removed NCS pathway item.
+        :type ncs_pathway_uuid: str
+        """
+        self.implementation_model_view.remove_ncs_pathway_items(ncs_pathway_uuid)
 
     def enable_default_items(self, enable: bool):
         """Enable or disable default NCS pathway and implementation model items.

--- a/src/cplus_plugin/gui/model_component_widget.py
+++ b/src/cplus_plugin/gui/model_component_widget.py
@@ -305,6 +305,7 @@ class NcsComponentWidget(ModelComponentWidget):
     """Widget for displaying and managing NCS pathways."""
 
     ncs_pathway_updated = QtCore.pyqtSignal(NcsPathway)
+    ncs_pathway_removed = QtCore.pyqtSignal(str)
     items_reloaded = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
@@ -402,8 +403,9 @@ class NcsComponentWidget(ModelComponentWidget):
         ncs = selected_items[0].ncs_pathway
 
         msg = self.tr(
-            f"Do you want to remove '{ncs.name}'?\nClick Yes to "
-            f"proceed or No to cancel."
+            f"Do you want to remove '{ncs.name}'? The corresponding "
+            f"NCS pathways used in the implementation models will "
+            f"also be removed.\nClick Yes to proceed or No to cancel."
         )
 
         if (
@@ -416,6 +418,7 @@ class NcsComponentWidget(ModelComponentWidget):
             == QtWidgets.QMessageBox.Yes
         ):
             self.item_model.remove_ncs_pathway(str(ncs.uuid))
+            self.ncs_pathway_removed.emit(str(ncs.uuid))
             settings_manager.remove_ncs_pathway(str(ncs.uuid))
             self.clear_description()
 
@@ -754,3 +757,13 @@ class ImplementationModelComponentWidget(ModelComponentWidget):
         :rtype: bool
         """
         return self.item_model.update_ncs_pathway_items(ncs_pathway)
+
+    def remove_ncs_pathway_items(self, ncs_pathway_uuid: str):
+        """Delete NCS pathway items used for IMs that are linked to the
+        given NCS pathway.
+
+        :param ncs_pathway_uuid: NCS pathway whose corresponding items will be
+        deleted in the implementation model items that contain it.
+        :type ncs_pathway_uuid: str
+        """
+        self.item_model.remove_ncs_pathway_items(ncs_pathway_uuid)


### PR DESCRIPTION
Synchronizes the deletion of NCS pathways defined under implementation models when the reference NCS pathway (in NCS Pathways list view) is removed.