### PR TITLE
Report Framework Enhancements

### DIFF
--- a/src/cplus_plugin/definitions/constants.py
+++ b/src/cplus_plugin/definitions/constants.py
@@ -31,3 +31,5 @@ PIXEL_VALUE_ATTRIBUTE = "style_pixel_value"
 STYLE_ATTRIBUTE = "style"
 USER_DEFINED_ATTRIBUTE = "user_defined"
 UUID_ATTRIBUTE = "uuid"
+
+MODEL_IDENTIFIER_PROPERTY = "model_identifier"

--- a/src/cplus_plugin/definitions/defaults.py
+++ b/src/cplus_plugin/definitions/defaults.py
@@ -216,21 +216,3 @@ DEFAULT_REPORT_DISCLAIMER = (
 DEFAULT_REPORT_LICENSE = (
     "Creative Commons Attribution 4.0 International " "License (CC BY 4.0)"
 )
-
-# KEY: Implementation model identifier, VALUE: pixel value
-DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES = {
-    "a0b8fd2d-1259-4141-9ad6-d4369cf0dfd4": 1,
-    "1c8db48b-717b-451b-a644-3af1bee984ea": 2,
-    "de9597b2-f082-4299-9620-1da3bad8ab62": 3,
-    "40f04ea6-1f91-4695-830a-7d46f821f5db": 4,
-    "43f96ed8-cd2f-4b91-b6c8-330d3b93bcc1": 5,
-    "c3c5a381-2b9f-4ddc-8a77-708239314fb6": 6,
-    "3defbd0e-2b12-4ab2-a7d4-a035152396a7": 7,
-    "22f9e555-0356-4b18-b292-c2d516dcdba5": 8,
-    "177f1f27-cace-4f3e-9c3c-ef2cf54fc283": 9,
-    "4fbfcb1c-bfd7-4305-b216-7a1077a2ccf7": 10,
-    "d9d00a77-3db1-4390-944e-09b27bcbb981": 11,
-    "20491092-e665-4ee7-b92f-b0ed864c7312": 12,
-    "1334cc3b-cb7b-46a3-923a-45d9b18d9d56": 13,
-    "92054916-e8ea-45a0-992c-b6273d1b75a7": 14,
-}

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -856,7 +856,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             name=self.analysis_scenario_name,
             description=self.analysis_scenario_description,
             extent=self.analysis_extent,
-            models=self.analysis_implementation_models,
+            models=self.analysis_weighted_ims,
             priority_layer_groups=self.analysis_priority_layers_groups,
         )
 

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -96,6 +96,7 @@ from ..definitions.defaults import (
 from ..definitions.constants import (
     IM_GROUP_LAYER_NAME,
     IM_WEIGHTED_GROUP_NAME,
+    MODEL_IDENTIFIER_PROPERTY,
     NCS_PATHWAYS_GROUP_LAYER_NAME,
     USER_DEFINED_ATTRIBUTE,
 )
@@ -2374,6 +2375,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             for im in list_models:
                 im_name = im.name
                 im_layer = QgsRasterLayer(im.path, im.name)
+                im_layer.setCustomProperty(MODEL_IDENTIFIER_PROPERTY, str(im.uuid))
                 list_pathways = im.pathways
 
                 # Add IM layer with styling, if available
@@ -2430,6 +2432,11 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
                 im_weighted_layer = QgsRasterLayer(
                     weighted_im_path, weighted_im_name, QGIS_GDAL_PROVIDER
+                )
+
+                # Set UUID for easier retrieval
+                im_weighted_layer.setCustomProperty(
+                    MODEL_IDENTIFIER_PROPERTY, str(model.uuid)
                 )
 
                 renderer = self.style_model_layer(im_weighted_layer, model)

--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -2268,6 +2268,7 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             self.update_progress_bar(100)
             self.scenario_result.analysis_output = output
             self.scenario_result.state = ScenarioState.FINISHED
+            self.scenario_result.scenario_directory = self.scenario_directory
             self.analysis_finished.emit(self.scenario_result)
 
         else:

--- a/src/cplus_plugin/lib/reports/generator.py
+++ b/src/cplus_plugin/lib/reports/generator.py
@@ -32,7 +32,6 @@ from qgis.core import (
     QgsRasterLayer,
     QgsReadWriteContext,
     QgsScaleBarSettings,
-    QgsSimpleLegendNode,
     QgsTask,
     QgsTableCell,
     QgsTextFormat,
@@ -114,7 +113,7 @@ class ReportGeneratorTask(QgsTask):
         if self._context.project_file:
             self._result = self._generator.run()
         else:
-            msg = tr("Unable to serialize current project for " "report generation.")
+            msg = tr("Unable to serialize current project for report generation.")
             msgs: typing.List[str] = [msg]
             self._result = ReportResult(
                 False, self._context.scenario.uuid, "", tuple(msgs)
@@ -386,29 +385,27 @@ class ReportGenerator:
     def output_dir(self) -> str:
         """Creates, if it does not exist, the output directory
         where the analysis reports will be saved. This is relative
-        to the base directory and outputs sub-folder.
+        to the base directory and scenario output sub-folder.
 
         :returns: Output directory where the analysis reports
         will be saved.
         :rtype: str
         """
-        output_dir = f"{self._context.scenario_output_dir}/reports"
-
         # Create reports directory
         if not self._report_output_dir:
-            p = Path(output_dir)
+            p = Path(self._context.scenario_output_dir)
             if not p.exists():
                 try:
                     p.mkdir()
                 except FileNotFoundError:
                     tr_msg = (
                         "Missing parent directory when creating "
-                        "reports subdirectory."
+                        "'report' subdirectory."
                     )
                     self._error_messages.append(tr_msg)
                     return ""
 
-        self._report_output_dir = output_dir
+        self._report_output_dir = self._context.scenario_output_dir
 
         return self._report_output_dir
 

--- a/src/cplus_plugin/lib/reports/generator.py
+++ b/src/cplus_plugin/lib/reports/generator.py
@@ -972,14 +972,10 @@ class ReportGenerator:
             name_cell.setBackgroundColor(QtGui.QColor("#e9e9e9"))
 
             # IM area
-            im_uuid = str(imp_model.uuid)
-            if im_uuid in DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES:
-                im_pixel_value = DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES[im_uuid]
-                area_info = pixel_area_info.get(im_pixel_value, None)
-                if area_info is None:
-                    area_info = "0"
+            if imp_model.style_pixel_value in pixel_area_info:
+                area_info = pixel_area_info.get(imp_model.style_pixel_value)
             else:
-                area_info = tr("<Pixel value not found>")
+                area_info = tr("<Pixel value not found in calculation>")
 
             area_cell = QgsTableCell(area_info)
             if isinstance(area_info, Number):

--- a/src/cplus_plugin/lib/reports/generator.py
+++ b/src/cplus_plugin/lib/reports/generator.py
@@ -44,7 +44,6 @@ from qgis.PyQt import QtCore, QtGui, QtXml
 
 from ...definitions.constants import IM_GROUP_LAYER_NAME
 from ...definitions.defaults import (
-    DEFAULT_IMPLEMENTATION_MODEL_PIXEL_VALUES,
     IMPLEMENTATION_MODEL_AREA_TABLE_ID,
     MINIMUM_ITEM_HEIGHT,
     MINIMUM_ITEM_WIDTH,

--- a/src/cplus_plugin/models/base.py
+++ b/src/cplus_plugin/models/base.py
@@ -576,3 +576,4 @@ class ScenarioResult:
     created_date: datetime.datetime = datetime.datetime.now()
     analysis_output: typing.Dict = None
     output_layer_name: str = ""
+    scenario_directory: str = ""

--- a/src/cplus_plugin/utils.py
+++ b/src/cplus_plugin/utils.py
@@ -220,7 +220,7 @@ def calculate_raster_value_area(
         pixel_value = f.attribute(0)
         area = f.attribute(2)
         pixel_value_area = area_calc.convertAreaMeasurement(area, unit_type)
-        pixel_areas[int(pixel_value)] = pixel_value_area
+        pixel_areas[pixel_value] = pixel_value_area
 
     return pixel_areas
 


### PR DESCRIPTION
This PR includes:
1. A fix for correctly calculating the implementation model area in the scenario layer using the pixel value;
2. Removal of default implementation model mapping to corresponding pixel value as this is now part of the IM API;
3. Reports are now saved under the respective scenario directory instead of the `outputs` folder;
4. Inclusion of area calculation for each IM layer. The area values will be included in the updated report layout<sup>1</sup>. 


**Notes:**
<sup>1</sup>The area calculation for some implementation models can be very slow due to the number of unique pixel values when using the `native:rasterlayeruniquevaluesreport` processing algorithm. Need to explore other fast options for iterating the number of pixels of a raster layer e.g. `numpy`