### PR TITLE
Update processing output files paths creation

### DIFF
--- a/src/cplus_plugin/gui/qgis_cplus_main.py
+++ b/src/cplus_plugin/gui/qgis_cplus_main.py
@@ -919,9 +919,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 f" [{dest_crs.authid()}]"
             )
 
-            output_file = (
-                f"{self.scenario_directory}/"
-                f"{SCENARIO_OUTPUT_FILE_NAME}_{str(scenario.uuid)[:4]}.tif"
+            output_file = os.path.join(
+                self.scenario_directory,
+                f"{SCENARIO_OUTPUT_FILE_NAME}_{str(scenario.uuid)[:4]}.tif",
             )
 
             # Preparing the input rasters for the highest position
@@ -1100,8 +1100,8 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
 
             file_name = clean_filename(pathway.name.replace(" ", "_"))
 
-            output_file = (
-                f"{new_carbon_directory}/{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            output_file = os.path.join(
+                new_carbon_directory, f"{file_name}_{str(uuid.uuid4())[:4]}.tif"
             )
 
             if suitability_index > 0:
@@ -1508,7 +1508,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             FileUtils.create_new_dir(new_ims_directory)
             file_name = clean_filename(pathway.name.replace(" ", "_"))
 
-            output_file = f"{new_ims_directory}/{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            output_file = os.path.join(
+                new_ims_directory, f"{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            )
 
             pathway_layer = QgsRasterLayer(pathway.path, pathway.name)
             provider = pathway_layer.dataProvider()
@@ -1672,7 +1674,9 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 main_task.cancel()
                 return False
 
-            output_file = f"{new_ims_directory}/{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            output_file = os.path.join(
+                new_ims_directory, f"{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            )
 
             # Due to the implementation models base class
             # model only one of the following blocks will be executed,
@@ -1832,13 +1836,14 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
                 main_task.cancel()
                 return False
 
-            basenames = []
             layers = []
-            new_ims_directory = f"{self.scenario_directory}/normalized_ims"
-            FileUtils.create_new_dir(new_ims_directory)
+            normalized_ims_directory = f"{self.scenario_directory}/normalized_ims"
+            FileUtils.create_new_dir(normalized_ims_directory)
             file_name = clean_filename(model.name.replace(" ", "_"))
 
-            output_file = f"{new_ims_directory}/{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            output_file = os.path.join(
+                normalized_ims_directory, f"{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            )
 
             model_layer = QgsRasterLayer(model.path, model.name)
             provider = model_layer.dataProvider()
@@ -2065,12 +2070,16 @@ class QgisCplusMain(QtWidgets.QDockWidget, WidgetUi):
             if basenames is []:
                 return
 
-            new_ims_directory = f"{self.scenario_directory}/weighted_ims"
+            weighted_ims_directory = f"{self.scenario_directory}/weighted_ims"
 
-            FileUtils.create_new_dir(new_ims_directory)
+            FileUtils.create_new_dir(weighted_ims_directory)
 
             file_name = clean_filename(model.name.replace(" ", "_"))
-            output_file = f"{new_ims_directory}/{file_name}_{str(uuid.uuid4())[:4]}.tif"
+
+            output_file = os.path.join(
+                weighted_ims_directory, f"{file_name}_{str(uuid.uuid4())[:4]}.tif"
+            )
+
             expression = " + ".join(basenames)
 
             # Actual processing calculation


### PR DESCRIPTION
When creating processing operations output the files paths were using forward slash as a separator, these changes remove the forward slash separation and uses `os.path.join` function to separate file path segments.